### PR TITLE
[AMENDMENT] Corrects spelling of Bitwarden

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ A Codeberg mirror is available [here](https://codeberg.org/alicia/awesome-privac
 
 | Provider | Description |
 | --- | --- |
-**[BitWarden](https://bitwarden.com)**  | Fully-featured, open source password manager with cloud-sync. BitWarden is easy-to-use with a clean UI and client apps for desktop, web and mobile.
+**[Bitwarden](https://bitwarden.com)**  | Fully-featured, open source password manager with cloud-sync. Bitwarden is easy-to-use with a clean UI and client apps for desktop, web and mobile.
 **[KeePass](https://keepass.info)** | Hardened, secure and offline password manager. Does not have cloud-sync baked in, deemed to be [gold standard](https://keepass.info/ratings.html) for secure password managers. KeePass clients: [Strongbox](https://apps.apple.com/us/app/strongbox-keepass-pwsafe/id897283731) *(Mac & iOS)*, [KeePassDX](https://play.google.com/store/apps/details?id=com.kunzisoft.keepass.free) *(Android)*, [KeeWeb](https://keeweb.info) *(Web-based/ self-hosted)*, [KeePassXC](https://keepassxc.org) *(Windows, Mac & Linux)*, see more KeePass clients and extensions at [awesome-keepass](https://github.com/lgg/awesome-keepass) by @lgg. 
 **[LessPass](https://lesspass.com)** *(Self-Hosted)* | LessPass is a little different, since it generates your passwords using a hash of the website name, your username and a single main-passphrase that you reuse. It omits the need for you to ever need to store or sync your passwords. They have apps for all the common platforms and a CLI, but you can also self-host it.
 **[Padloc](https://padloc.app)** | A modern, open source password manager for individuals and teams. Beautiful, intuitive and dead simple to use. Apps available for all platforms and you can self-host it as well.


### PR DESCRIPTION
Correcting the capitalisation of Bitwarden (as on their website)


<!--
Thank you for contributing to Awesome-Privacy! 🙌
Before submitting, please read .github/CONTRIBUTING.md, 
And ensure that your pull request follows the guidelines.
-->

### Type
<!-- Delete as appropriate. This is used to auto-apply labels. -->

Spelling or Grammar

---

### Changes
<!-- Briefly outline your changes, and if necessary explain why -->

The app and website uses “Bitwarden” and not, as this says, “BitWarden”.

---

### Supporting Material
<!-- For new entries, provide relevant links. E.g. Git repo, security audit, docs, etc -->

The website and app

---

### Affiliation
<!--
For transparency, please indicate weather or not you are associated with the software being added / edited.
If this is a deletion, you should also disclose your affiliation with and other project within the same category.
-->

I’m a happy customer, but that’s all.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid markdown formatting, spelling and grammar)
- [x] I have indicated whether I have any affiliation with any software/ services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

