### PR TITLE
Replace Simple Mobile Tools by Fossify

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1663,7 +1663,7 @@ Only install from official sources.
 > [Oasis Feng](https://play.google.com/store/apps/dev?id=7664242523989527886),
 > [Marcel Bokhorst](https://play.google.com/store/apps/dev?id=8420080860664580239),
 > [SECUSO Research Group]( https://play.google.com/store/apps/developer?id=SECUSO+Research+Group&hl=en_US)
-> and [Simple Mobile Tools](https://play.google.com/store/apps/dev?id=9070296388022589266) -
+> and [Fossify](https://github.com/FossifyOrg) -
 > all of which are trusted developers or organisations, who've done amazing work.
 > 
 > For offensive and defensive security, see


### PR DESCRIPTION
### Changes
Simple Mobile Tools is no longer a good recommendation. It's better to mention its fork "Fossify"

### Supporting Material
Eveything is on Github: https://github.com/FossifyOrg
FDroid guys build the apks.

### Affiliation
<!--
For transparency, please indicate whether or not you are associated with the software being added / edited.
If this is a deletion, you should also disclose your affiliation with and other project within the same category.
-->
I'm a basic user of some Fossify apps.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

