### PR TITLE
Add Pico to Blogging Platforms

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4822,6 +4822,14 @@ categories:
         url: https://movim.eu/
         github: movim/movim
 
+      - name: Pico
+        description: |
+          Web services over SSH, including blogging with Prose, microsites with Pages, and a pastebin with
+          Pastes. The services use public-key cryptography by default with no browser-based tracking and
+          minimal logging.
+        url: https://pico.sh/
+        github: picosh/pico
+        openSource: true
 
       notableMentions: |
         If you use [Standard Notes](https://standardnotes.com/?s=chelvq36),


### PR DESCRIPTION
### Type
Addition

---

### Changes
Added Pico to Blogging Platforms section. Pico is similar to Bear Blog in that it provides a minimal approach to blogging. Pico provides a number of services over SSH, including blogging, microsites, and pastebins in their free tier.

---

### Supporting Material
https://github.com/picosh/pico
https://pico.sh/
https://pico.sh/privacy
https://pico.sh/about

---

### Affiliation
I do not have any affiliation with Pico or any of its projects - I just think they are a super cool tool!

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

