### PR TITLE
Fix validate flags

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -775,7 +775,7 @@ categories:
         icon: https://mailfence.com/c/mailfence/images/favicon/android-chrome-192x192.png
         openSource: false
         tosdrId: 1694
-        reddit: Mailfence
+        subreddit: Mailfence
         androidApp: com.contactoffice.mailfence
         iosApp: https://apps.apple.com/us/app/mailfence/id1628808776
         description: |
@@ -792,7 +792,7 @@ categories:
         icon: https://i.ibb.co/zJtHBTZ/mailfence.png
         openSource: false
         tosdrId: 1517
-        reddit: Mailbox_org
+        subreddit: Mailbox_org
         description: |
           A Berlin-based, eco-friendly secure mail provider. There is no free plan, the
           standard service costs €12/year. You can use your own domain, with the option of
@@ -837,7 +837,7 @@ categories:
       - name: Mozilla Thunderbird
         url: https://www.thunderbird.net
         icon: https://www.thunderbird.net/media/img/thunderbird/ios-icon-180.png
-        reddit: Thunderbird
+        subreddit: Thunderbird
         openSource: true
         tosdrId: 3365
         description: |


### PR DESCRIPTION
### Type
Amendment

---

### Changes
I noticed that `make validate` was failing with the following error on 3 lines: 
```
WARNING:__main__:Validation error: Additional properties are not allowed ('reddit' was unexpected)
```
I updated the lines using the additional `reddit` property to use the `subreddit` property as described in the schema so that the validation will pass again without warnings.

---

### Supporting Material
https://github.com/Lissy93/awesome-privacy/blob/main/lib/schema.json#L35
Line 35 of the repo's schema file declares a `subreddit` property. There is no `reddit` property available. 

---

### Affiliation
N/A

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

