### PR TITLE
fix: fixed typo `Saftey` -> `Safety`

### DIFF
--- a/web/src/components/things/WebsiteDetailedInfo.astro
+++ b/web/src/components/things/WebsiteDetailedInfo.astro
@@ -132,7 +132,7 @@ const screenshotUrl = `https://screenshot-cache.as93.workers.dev/${url}`;
         </li>
       ))}
     </ul>
-    <h4>Saftey Score</h4>
+    <h4>Safety Score</h4>
     <p class="explainer">Website marked as {riskText}</p>
     <div class={`risk risk-${riskText.replaceAll(' ', '-').toLocaleLowerCase()}`}>
       <p>{100-risk}%</p>


### PR DESCRIPTION
team here from @forwardemail, just spotted this typo