### PR TITLE
add InstagramPrivSniffer

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1790,7 +1790,7 @@ categories:
       services:
         - name: InstagramPrivSniffer
           github: obitouka/InstagramPrivSniffer
-          icon: https://github.com/obitouka/InstagramPrivSniffer/blob/main/img/logo.png
+          icon: https://github.com/obitouka/InstagramPrivSniffer/blob/main/assets/img/logo.png
           description: |
             Even if you have 0% idea about them, see what they don’t want you to i.e. every collaborated post and 
             who they collaborated with from a private account, revealed by colllaborating with a public profile (all without logging in!)

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1788,6 +1788,13 @@ categories:
       intro: >
         A selection of free online tools and utilities, to check, test and protect your security
       services:
+        - name: InstagramPrivSniffer
+          github: obitouka/InstagramPrivSniffer
+          icon: https://github.com/obitouka/InstagramPrivSniffer/blob/main/img/logo.png
+          description: |
+            Even if you have 0% idea about them, see what they don’t want you to i.e. every collaborated post and 
+            who they collaborated with from a private account, revealed by colllaborating with a public profile (all without logging in!)
+            
         - name: Have i been pwned
           url: https://haveibeenpwned.com
           icon: https://i.ibb.co/XxmfTyw/haveibeenpwnd.png
@@ -4703,6 +4710,12 @@ categories:
         should be able to choose with whom you share what, and that is what the
         following sites aim to do.
       services:
+      - name: InstagramPrivSniffer
+        description: |
+            Even if you have 0% idea about them, see what they don’t want you to i.e. every collaborated post and 
+            who they collaborated with from a private account, revealed by colllaborating with a public profile (all without logging in!)
+        github: obitouka/InstagramPrivSniffer
+            
       - name: Aether
         description: |
           Offers self-governing communities with auditable moderation, akin to Reddit but


### PR DESCRIPTION
### Type
Addition

---

### Changes
Added **InstagramPrivSniffer** to the **Online Tools & Social Network** section.  
It’s  a python OSINT CLI tool that reveals private Instagram posts (via public collaborators) without login, all legally.

---

### Supporting Material
- GitHub Repo: [https://github.com/obitouka/InstagramPrivSniffer](https://github.com/obitouka/InstagramPrivSniffer)  
- Docs: [README](https://github.com/obitouka/InstagramPrivSniffer/blob/main/README.md)  
- Instagram Collaboration Feature: [Official help article](https://help.instagram.com/)

---

### Affiliation
I am the creator of this tool. This addition is for **educational and research purposes only**.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements  
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)  
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
