### PR TITLE
Add Vault Password Generator to Password Managers

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -104,6 +104,15 @@ categories:
         description: The Standard Unix Password Manager
         openSource: true
 
+      - name: Vault Password Generator
+        url: https://jarrydgordon.github.io/vault-demo/
+        github: JarrydGordon/vault-demo
+        openSource: true
+        description: >
+          Client-side password and passphrase generator. Single HTML file with no
+          server component — runs entirely in the browser using the Web Crypto API.
+          No data collection, no accounts, works offline.
+
       notableMentions:
       - name: Password Safe
         url: https://www.pwsafe.org


### PR DESCRIPTION
Adding Vault Password Generator to the Password Managers section.

**What it is:** A client-side password and passphrase generator — single HTML file, no server, no data collection.

**Privacy relevance:**
- Runs entirely in the browser (Web Crypto API)
- Zero network calls during generation — verifiable via DevTools
- No analytics, no cookies, no tracking
- Works offline — save the file and disconnect
- Open source (MIT)

[Live demo](https://jarrydgordon.github.io/vault-demo/) | [Source](https://github.com/JarrydGordon/vault-demo)