### PR TITLE
 Added Yundera to the Cloud Hosting section.

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2869,6 +2869,17 @@ categories:
           crypto-currencies (Bitcoin, Monero, Ethereum etc..) and don't require any personal informations. They resell from
           reputable providers.
 
+      - name: Yundera
+        url: https://yundera.com
+        openSource: true
+        github: Yundera
+        description: |
+          An open source Private Cloud Server stack making self hosting reliable and accessible. Yundera simplifies
+          self-hosting by handling app maintenance automatically, including updates and preventing system regressions.
+          Features include MeshRouter for domain management, CasaOS interface for server management, and an AppStore
+          with pre-configured applications. Designed to make self-hosting accessible for both experts and newcomers.
+          [GitHub](https://github.com/yundera)
+
       notableMentions: |
         See also: [1984](https://www.1984.is) based in Iceland.
         [Shinjiru](http://shinjiru.com?a_aid=5e401db24a3a4), which offers off-shore dedicated servers.


### PR DESCRIPTION
### Type
Addition

---

### Changes
Added Yundera to the Cloud Hosting section.

Yundera is an open source Private Cloud Server stack that makes self-hosting reliable and accessible. It simplifies self-hosting by handling app maintenance automatically, including updates and preventing system regressions. Features include MeshRouter for domain management, CasaOS interface for server management, and an AppStore with pre-configured applications.

---

### Supporting Material
- Website: https://yundera.com
- GitHub: https://github.com/yundera
- Open Source: Yes

---

### Affiliation
I am affiliated with the Yundera team.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
