### PR TITLE
 Added NSL.SH to the DNS Hosting section.

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2920,7 +2920,19 @@ categories:
         followWith: Web
         description: |
           Free DNS hosting provider designed with security in mind, and running
-          on purely open source software. deSEC is backed and funded by SSE. 
+          on purely open source software. deSEC is backed and funded by SSE.
+
+      - name: NSL.SH
+        url: https://nsl.sh
+        openSource: true
+        github: yundera/mesh-router-tunnel
+        followWith: Self-Hosted
+        description: |
+          A free and open-source domain and domain routing service for independent home server setups. Provides
+          personalized subdomains (name.nsl.sh) with automatic HTTPS/TLS encryption. Integrates with CasaOS for
+          simplified Docker container management and claims a 5-minute setup process. Completely free with no
+          paywall-locked features, maintained by Aptero.
+          [GitHub](https://github.com/yundera/mesh-router-tunnel)
 
 
     ###########################


### PR DESCRIPTION
### Type
Addition

---

### Changes
Added NSL.SH to the DNS Hosting section.

NSL.SH is a free and open-source domain and domain routing service for independent home server setups. It provides personalized subdomains (name.nsl.sh) with automatic HTTPS/TLS encryption, integrates with CasaOS for simplified Docker container management, and offers a quick 5-minute setup process. Completely free with no paywall-locked features.

---

### Supporting Material
- Website: https://nsl.sh
- GitHub: https://github.com/yundera/mesh-router-tunnel
- Open Source: Yes
- Maintained by: Aptero

---

### Affiliation
I am affiliated with the Yundera team.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
