### PR TITLE
Remove Budget Zen

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4723,9 +4723,8 @@ categories:
         [Smart Wallet](https://apps.apple.com/app/smart-wallet/id1378013954) (iOS),
         [My-Budget](https://rezach.github.io/my-budget) (Desktop),
         [MoneyManager EX](https://www.moneymanagerex.org),
-        [Skrooge](https://skrooge.org),
-        [kMyMoney](https://kmymoney.org) and
-        [Budget Zen](https://budgetzen.net) (a simple E2E encrypted budget manager)
+        [Skrooge](https://skrooge.org), and
+        [kMyMoney](https://kmymoney.org).
 
 
   - name: Social


### PR DESCRIPTION
### Type

Removal

---

### Changes

Removed Budget Zen, as it was archived almost a year ago.

---

### Supporting Material

- https://github.com/BrunoBernardino/budgetzen-web

---

### Affiliation

I am the creator/owner of Budget Zen.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)