### PR TITLE
Adds VerifySMS to Virtual Phone Numbers

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1161,6 +1161,14 @@ categories:
           Anonymous SMS service able to activate accounts. Accessible over web, CLI, or
           email. Pricing starts at $3.60 / month. The service is in beta as of 2022.
 
+      - name: VerifySMS
+        url: https://verifysms.app
+        icon: https://verifysms.app/apple-touch-icon.png
+        description: |
+          Virtual phone numbers for SMS verification in 150+ countries. Pricing starts
+          at $0.20 per verification. iOS app available. Automatic refund if no SMS is
+          received within the timeout period.
+
     ################################
     ###### Team Collaboration ######
     ################################


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds [VerifySMS](https://verifysms.app) to the Virtual Phone Numbers section. VerifySMS provides virtual phone numbers for SMS verification in 150+ countries, with pricing starting at $0.20 per verification and automatic refunds if no SMS is received.

---

### Supporting Material
- Website: https://verifysms.app
- iOS App: Available on App Store

---

### Affiliation
I am affiliated with VerifySMS.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)