### PR TITLE
Add Uruky

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -527,6 +527,17 @@ categories:
         description: |
           British search engine providing independent and unbiased search results using
           its own crawler. Has a zero tracking policy (it is not open source)
+      
+      - name: Uruky
+        url: https://uruky.com
+        icon: https://uruky.com/public/images/favicon.svg
+        iosApp: https://apps.apple.com/us/app/uruky-private-ad-free-search/id6758864380
+        description: |
+          Uruky is an ad-free, private search engine focused on personalization. It uses,
+          among other providers, Mojeek and Marginalia. It is EU-based and does not keep
+          or track any personal data (it is not 100% open source, but after 12 months as
+          a paying customer, you get a copy of the source code).
+      
       notableMentions:
       - name: MetaGear
         url: https://metager.org


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds Uruky.

While it's not "usual" open source, the code is eventually shared with customers and they can use it as they like, except for commercial purposes or sharing it with other people.

Hopefully it's an important option enough to be added to the list. We regularly talk about it as being a EU-based [Kagi](https://kagi.com) alternative.

---

### Supporting Material

- https://uruky.com

---

### Affiliation

I'm one of two owners of the company that owns Uruky (the other's my wife). I've built a lot of its technology.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

