### PR TITLE
Adds FCaptcha to Self-Hosted Network Security

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2161,6 +2161,16 @@ categories:
         description: |
           Open-source self-hosted VPN and firewall built on WireGuard®.
 
+      - name: FCaptcha
+        url: https://webdecoy.com/product/fcaptcha/
+        github: WebDecoy/FCaptcha
+        openSource: true
+        icon: https://webdecoy.com/favicon.svg
+        description: |
+          Self-hosted CAPTCHA that detects bots, vision AI agents, and
+          headless browsers through behavioral analysis and SHA-256 proof
+          of work. No fingerprinting, no tracking, no external dependencies.
+
     ##########################
     ###### Mix networks ######
     ##########################


### PR DESCRIPTION
## Summary
Adds FCaptcha to the Self-Hosted Network Security section as a privacy-respecting, self-hosted CAPTCHA and bot detection tool.

## About FCaptcha
- Open source (MIT), fully self-hosted
- No persistent fingerprinting, no cross-site tracking, no cookies
- No external dependencies or data sharing
- Auditable scoring algorithms
- Behavioral analysis and SHA-256 proof of work
- Servers in Go, Python, and Node.js

## Checklist
- [x] Privacy respecting — no tracking, no cookies, no data collection
- [x] Secure — proof of work + behavioral signals
- [x] Open source — MIT licensed, full source on GitHub
- [x] Actively maintained
- [x] Transparent — open algorithm, auditable scoring
- [x] Functional — stable release with Docker deployment

## Disclosure
I am the maintainer of FCaptcha.

## Links
- GitHub: https://github.com/WebDecoy/FCaptcha
- Demo: https://webdecoy.com/product/fcaptcha-demo/