### PR TITLE
Adds Telegram Archive to Backup and Sync

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3179,6 +3179,17 @@ categories:
           Unifies file management, sync, sharing, notes, RSS, expenses, calendars,
           contacts, and photos, with MFA, WebDAV, CalDAV, CardDAV, SSO, and more.
 
+      - name: Telegram Archive
+        url: https://github.com/GeiserX/Telegram-Archive
+        icon: https://raw.githubusercontent.com/GeiserX/Telegram-Archive/master/assets/Telegram-Archive.png
+        github: GeiserX/Telegram-Archive
+        openSource: true
+        description: |
+          Self-hosted Telegram backup tool running on Docker. Performs automated
+          incremental backups of messages and media on a configurable schedule,
+          with a built-in web viewer. All data stays on your own infrastructure
+          with no cloud dependency.
+
       notableMentions: |
         Alternatively, consider a headless utility such as [Duplicacy](https://duplicacy.com)
         or [Duplicity](http://duplicity.nongnu.org).


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds [Telegram Archive](https://github.com/GeiserX/Telegram-Archive) to the **Backup and Sync** section.

Telegram Archive is a self-hosted Telegram backup tool that runs on Docker. It performs automated incremental backups of messages and media on a configurable schedule, with a built-in web viewer. All data stays on the user's own infrastructure with no cloud dependency. Licensed under GPL-3.0.

---

### Supporting Material

- **Git repo**: https://github.com/GeiserX/Telegram-Archive
- **License**: GPL-3.0
- **Stars**: 83+
- **Docker-based**: Easy deployment via Docker Compose
- **Privacy features**: Fully self-hosted, no cloud dependency, all data stored locally under user control

---

### Affiliation

I am the author and maintainer of Telegram Archive.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)