### PR TITLE
Add SaneHosts

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2709,6 +2709,18 @@ categories:
         description: |
           Comprehensive list of domains for blocking tracking, social scripts, bad cookies and annoying stuff.
 
+      - name: SaneHosts
+        url: https://sanehosts.com
+        github: sane-apps/SaneHosts
+        icon: https://sanehosts.com/favicon.ico
+        followWith: macOS
+        description: |
+          Native macOS hosts file manager for system-wide ad and tracker blocking.
+          Choose from 5 curated protection levels, each bundles the right blocklists.
+          All blocking is done via /etc/hosts, reaching all apps system-wide.
+          No telemetry, no cloud, no account required. PolyForm Shield licensed
+          (open code for personal use).
+
       - name: iBlockList
         url: https://www.iblocklist.com
         icon: https://d3pkfiqitivr8j.cloudfront.net/sitefiles/images/favicon.ico


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds SaneHosts to the Host Block Lists section.

SaneHosts is a native macOS hosts file manager that makes blocking ads, trackers, and malware simple. Choose from 5 curated protection levels — each bundles the right blocklists. All blocking is done via /etc/hosts, so it works system-wide across all apps (not just the browser). No Terminal commands needed — choose a level, activate, done.

---

### Supporting Material

- Website: https://sanehosts.com
- Source: https://github.com/sane-apps/SaneHosts
- License: PolyForm Shield (open code for personal use)

---

### Affiliation

I am the developer of SaneHosts.

---

### Checklist

- [x] Respects user privacy — no telemetry, no analytics, no cloud, no account required
- [x] All data stays on device
- [x] Source code publicly available on GitHub
- [x] Actively maintained (latest release February 2026)
- [x] Functional with stable release
- [x] Only edited `awesome-privacy.yml`
- [x] Entry placed in existing Host Block Lists section