### PR TITLE
Adds SaneHosts to Host Block Lists

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2716,6 +2716,17 @@ categories:
           Variety of lists (free and paid-for) for blocking content based on certain topics, inducing: spam, abuse,
           political, illegal, hijacked, bad peers and more.
 
+      - name: SaneHosts
+        url: https://sanehosts.com
+        github: sane-apps/SaneHosts
+        icon: https://sanehosts.com/apple-touch-icon.png
+        openSource: true
+        followWith: macOS
+        description: >-
+          Native macOS hosts file manager with curated blocklists for system-wide
+          ad and tracker blocking. Five protection levels, no telemetry, no cloud.
+          Open source under PolyForm Shield.
+
     #############################
     ###### Router FirmWARE ######
     #############################


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds SaneHosts to the Host Block Lists section. Native macOS hosts file manager with 200K+ curated blocklist entries across five protection levels. All blocking via /etc/hosts — system-wide, no DNS proxy, no kernel extension.

---

### Supporting Material

- Website: https://sanehosts.com
- Source: https://github.com/sane-apps/SaneHosts
- License: PolyForm Shield — all code is public and free for personal use; the only restriction is competing commercial use

---

### Affiliation

I am the developer of SaneHosts.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)