### PR TITLE
Adds Tymeslot to Calendar

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3127,7 +3127,15 @@ categories:
     ######################
     - name: Calendar
       alternativeTo: ['google calendar', 'microsoft outlook calendar', 'apple calendar', 'yahoo calendar']
-      services: []
+      services:
+      - name: Tymeslot
+        url: https://tymeslot.app
+        followWith: Web, Docker, Cloudron
+        icon: https://tymeslot.app/images/brand/favicon.svg
+        description: |
+          Self-hostable appointment scheduling platform and privacy-respecting Calendly alternative.
+          Syncs with Google Calendar, Outlook, and CalDAV. Automatic video room creation, 90+ timezones,
+          no tracking or ads. Source code available under Elastic License 2.0.
 
     ###########################
     ###### Backup & Sync ######

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3131,6 +3131,7 @@ categories:
       - name: Tymeslot
         url: https://tymeslot.app
         followWith: Web, Docker, Cloudron
+        github: Tymeslot/tymeslot
         icon: https://tymeslot.app/images/brand/favicon.svg
         description: |
           Self-hostable appointment scheduling platform and privacy-respecting Calendly alternative.


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds Tymeslot to the Calendar category. The category currently has no entries — this is the first.

---

### Supporting Material

- Website: https://tymeslot.app
- Source code: https://github.com/Tymeslot/tymeslot
- Self-hosting docs: https://tymeslot.app/docs

Regarding the open source flag: Tymeslot is licensed under the Elastic License 2.0 (ELv2). The full source code is publicly available on GitHub, auditable, and forkable for self-hosting. ELv2 only restricts third parties from offering the software as a competing managed service — individual use, self-hosting, and contributing are fully permitted. This is the same license model used by Elastic, Grafana, and others that are widely recognised as open-source projects in practice.

---

### Affiliation

I am the author of Tymeslot.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)