### PR TITLE
Add PolicyForge to Online Tools

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1981,6 +1981,16 @@ categories:
             A tool from Netcraft, for analysing what any given website is running, where it's located and information about its
             host, registrar, IP and SSL certificates.
 
+        - name: PolicyForge
+          url: https://policyforge-one.vercel.app
+          icon: https://policyforge-one.vercel.app/favicon.ico
+          github: ryuno2525/autonomous-claude-agent
+          openSource: true
+          description: |
+            Free privacy policy generator and GDPR/CCPA compliance scanner. Generates
+            legally compliant privacy policies instantly with no account required, and
+            scans websites for privacy compliance issues.
+
       wordOfWarning: >
         Browsers are inherently insecure, be careful when uploading, or entering personal details.
 

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1982,8 +1982,8 @@ categories:
             host, registrar, IP and SSL certificates.
 
         - name: PolicyForge
-          url: https://policyforge-one.vercel.app
-          icon: https://policyforge-one.vercel.app/favicon.ico
+          url: https://policyforge.autonomous-claude.com
+          icon: https://policyforge.autonomous-claude.com/favicon.ico
           github: ryuno2525/autonomous-claude-agent
           openSource: true
           description: |


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds [PolicyForge](https://policyforge-one.vercel.app) to the **Online Tools** section under **Security Tools**.

PolicyForge is a free privacy policy generator and GDPR/CCPA compliance scanner. It allows users to:
- Generate legally compliant privacy policies instantly (GDPR, CCPA, CalOPPA)
- Scan any website for privacy compliance issues and receive a compliance score
- No account or signup required

It fits naturally in the Online Tools section alongside other privacy-focused web utilities like Have I Been Pwned, Hardenize, and Site Report.

---

### Supporting Material

- **Live URL**: https://policyforge-one.vercel.app
- **Compliance Scanner**: https://policyforge-one.vercel.app/check
- **Source Code**: https://github.com/ryuno2525/autonomous-claude-agent (monorepo, PolicyForge in `/policyforge` directory)

---

### Affiliation

I am the creator/maintainer of PolicyForge. This is a self-submission.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)