### PR TITLE
Add LNVPN to Virtual Phone Numbers

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1193,9 +1193,9 @@ categories:
           Privacy-focused eSIM provider for 170+ countries, with instant eSIM delivery.
           No account, ID, email needed, and accepts crypto via a self-hosted BTCPay Server.
 
-      - name: LNVPN
-        url: https://lnvpn.net
-        icon: https://lnvpn.net/favicon.ico
+      - name: nadanada
+        url: https://nadanada.me
+        icon: https://nadanada.me/favicon.ico
         acceptsCrypto: true
         description: >-
           Disposable (20-min) and extendable rental (3-month) phone numbers for

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1193,6 +1193,16 @@ categories:
           Privacy-focused eSIM provider for 170+ countries, with instant eSIM delivery.
           No account, ID, email needed, and accepts crypto via a self-hosted BTCPay Server.
 
+      - name: LNVPN
+        url: https://lnvpn.net
+        icon: https://lnvpn.net/favicon.ico
+        acceptsCrypto: true
+        description: >-
+          Disposable (20-min) and extendable rental (3-month) phone numbers for
+          anonymous SMS verification, plus anonymous eSIM data plans for 200+
+          countries. No account, no email, no KYC. Pay with Bitcoin, Monero,
+          stablecoins, other crypto, or credit card via Stripe.
+
     ################################
     ###### Team Collaboration ######
     ################################


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds LNVPN to the Virtual Phone Numbers section. LNVPN provides disposable and extendable rental phone numbers for anonymous SMS verification, plus anonymous eSIM data plans for 200+ countries. No account, email, or KYC required.

---

### Supporting Material

- Website: https://lnvpn.net
- Accessible via Tor
- Based in Berlin, Germany

---

### Affiliation

I am the developer of LNVPN.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)