### PR TITLE
Add Captchainbox to Email Security Tools

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1090,6 +1090,14 @@ categories:
           Verifies DKIM signatures and shows the result in the e-mail header, in order to help
           spot spoofed emails (which do not come from the domain that they claim to).
 
+      - name: Captchainbox
+        url: https://captchainbox.com
+        description: |
+          CAPTCHA-based email filtering for Gmail. Known contacts get through instantly,
+          while unknown senders receive an auto-reply with a simple CAPTCHA challenge.
+          Verified senders are automatically whitelisted. Helps block spam and unwanted
+          outreach without maintaining complex filter rules.
+
       notableMentions: >
         If you are using ProtonMail, then the [ProtonMail Bridge](https://protonmail.com/bridge/thunderbird)
         enables you to sync & backup your emails to your own desktop mail client.

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1092,11 +1092,11 @@ categories:
 
       - name: Captchainbox
         url: https://captchainbox.com
-        description: |
-          CAPTCHA-based email filtering for Gmail. Known contacts get through instantly,
-          while unknown senders receive an auto-reply with a simple CAPTCHA challenge.
-          Verified senders are automatically whitelisted. Helps block spam and unwanted
-          outreach without maintaining complex filter rules.
+        icon: https://captchainbox.com/logo-512.png
+        openSource: false
+        description: >-
+          CAPTCHA-based email filtering for Gmail. Known contacts pass through,
+          unknown senders verify via a simple CAPTCHA. Verified senders are auto-whitelisted.
 
       notableMentions: >
         If you are using ProtonMail, then the [ProtonMail Bridge](https://protonmail.com/bridge/thunderbird)


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds **Captchainbox** to the **Email Security Tools** section. Captchainbox is a CAPTCHA-based email filtering service for Gmail — known contacts pass through instantly, while unknown senders must complete a simple CAPTCHA to prove they're human.

---

### Supporting Material

- Website: https://captchainbox.com
- Product info: CAPTCHA-based email filtering for Gmail. Integrates via Google OAuth, uses Cloudflare Turnstile for verification challenges.

---

### Affiliation

I am the creator of Captchainbox.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

> **Note:** Captchainbox is not currently open source. It is listed as a practical email security tool for privacy-conscious users who want to reduce unwanted email without complex filter rules.