### PR TITLE
Add CloakBin in Pastebins

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3395,6 +3395,30 @@ categories:
 
 
     ###########################
+    ###########################
+    ###### Pastebins ######
+    ###########################
+    - name: Pastebins
+      alternativeTo: ['pastebin.com', 'hastebin', 'github gist']
+      services:
+      - name: CloakBin
+        url: https://cloakbin.com
+        github: Ishannaik/cloakbin-hosted
+        openSource: true
+        description: |
+          Zero-knowledge encrypted pastebin where AES-256-GCM encryption runs entirely in the browser.
+          The decryption key is stored only in the URL fragment (#key), which browsers never send to servers,
+          so even with full database access pastes are unreadable. Features syntax highlighting for 40+ languages,
+          burn-after-reading, custom expiry, and password protection.
+
+      - name: PrivateBin
+        url: https://privatebin.info
+        github: PrivateBin/PrivateBin
+        openSource: true
+        description: |
+          A minimalist, open-source online pastebin where the server has zero knowledge of pasted data.
+          Data is encrypted and decrypted in the browser using 256-bit AES. Requires self-hosting.
+
     ###### Browser Sync ######
     ##########################
     - name: Browser Sync

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3403,21 +3403,13 @@ categories:
       services:
       - name: CloakBin
         url: https://cloakbin.com
-        github: Ishannaik/cloakbin-hosted
+        icon: https://cloakbin.com/apple-touch-icon.png
+        github: Ishannaik/CloakBin
         openSource: true
         description: |
-          Zero-knowledge encrypted pastebin where AES-256-GCM encryption runs entirely in the browser.
-          The decryption key is stored only in the URL fragment (#key), which browsers never send to servers,
-          so even with full database access pastes are unreadable. Features syntax highlighting for 40+ languages,
-          burn-after-reading, custom expiry, and password protection.
-
-      - name: PrivateBin
-        url: https://privatebin.info
-        github: PrivateBin/PrivateBin
-        openSource: true
-        description: |
-          A minimalist, open-source online pastebin where the server has zero knowledge of pasted data.
-          Data is encrypted and decrypted in the browser using 256-bit AES. Requires self-hosting.
+          Zero-knowledge encrypted pastebin with client-side AES-256-GCM encryption.
+          The decryption key stays in the URL fragment, never sent to the server.
+          Features syntax highlighting, burn-after-reading, and password protection.
 
     ###### Browser Sync ######
     ##########################


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds a new **Pastebins** subsection under Productivity with CloakBin — an open-source zero-knowledge encrypted pastebin with client-side AES-256-GCM encryption. The decryption key stays in the URL fragment (#key), never sent to the server.

---

### Supporting Material

- Website: https://cloakbin.com
- Source code: https://github.com/Ishannaik/CloakBin
- License: AGPL-3.0
- Encryption: AES-256-GCM, client-side only, key in URL fragment

---

### Affiliation

I am the developer of CloakBin.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)