### PR TITLE
Adds Greywall to Linux Defenses

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4118,6 +4118,16 @@ categories:
           Clears cache and deletes temporary files very effectively. This frees up disk space, improves performance, but most
           importantly helps to protect privacy.
 
+      - name: Greywall
+        url: https://github.com/GreyhavenHQ/greywall
+        github: GreyhavenHQ/greywall
+        openSource: true
+        description: >-
+          Deny-by-default command sandbox with filesystem isolation and transparent
+          network redirection. Supports Linux (bubblewrap, seccomp, Landlock, eBPF)
+          and macOS (Seatbelt), with built-in profiles for AI coding agents and
+          learning mode for auto-generating configs.
+
       notableMentions: |
         [SecTools.org](https://sectools.org) is a directory or popular Unix security tools.
 


### PR DESCRIPTION
## Summary
Add Greywall to the Linux Defenses section.

Greywall is a deny-by-default command sandbox providing filesystem and network isolation using bubblewrap, seccomp, and Landlock on Linux and Seatbelt profiles on macOS. It sits alongside Firejail as a sandboxing tool but focuses on AI coding agent workflows with built-in agent profiles and learning mode.

## Affiliation
I am affiliated with the Greywall project.