### PR TITLE
Add HeyRobyn to Email Clients

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -982,6 +982,17 @@ categories:
           interface, with a dark mode option, it is also very lightweight and consumes minimal
           data usage.
 
+      - name: HeyRobyn
+        url: https://heyrobyn.ai
+        openSource: false
+        iosApp: https://heyrobyn.ai
+        description: |
+          Native macOS unified inbox for email, Slack, and GitHub. Built with SwiftUI for
+          performance and native integration. Privacy-first design with all data stored
+          on-device, no cloud sync. Aggregates multiple communication channels into a single
+          window, reducing context switching for developers and teams. Features include unified
+          search, notifications, and quick actions across all connected services.
+
       - name: K-9 Mail
         url: https://k9mail.app
         icon: https://k9mail.app/assets/img/k9-logo.svg


### PR DESCRIPTION
## HeyRobyn - Native macOS Email Client

**Website:** https://heyrobyn.ai

### Description
HeyRobyn is a privacy-first, native macOS unified inbox that aggregates email, Slack, and GitHub notifications into a single window. Built with SwiftUI for optimal performance and native integration with macOS.

### Privacy Features
- **All data on-device**: No cloud sync, all messages and credentials stored locally
- **Privacy-first design**: No telemetry, no tracking, no data collection
- **Native macOS app**: Built with SwiftUI (not Electron), uses system security features
- **Reduces digital footprint**: Consolidates communication channels to minimize context switching

### Why it fits this list
HeyRobyn belongs in the Email Clients section as a privacy-conscious alternative to cloud-based unified inbox solutions like Shift or Wavebox, which sync data to their servers. HeyRobyn keeps all data local and secure on your Mac.

### Platform
- macOS only (native SwiftUI app)
- Launching April 7, 2026

Thank you for maintaining this excellent resource!