### PR TITLE
Add Haveno DEX to Crypto Exchanges

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4685,6 +4685,17 @@ categories:
           invoices to minimize custody and trust requirements.
           The deterministically generated avatars help users stick to best privacy practices.
 
+      - name: Haveno
+        url: https://haveno.exchange
+        github: haveno-dex/haveno
+        openSource: true
+        description: |
+          Decentralized, open-source peer-to-peer exchange built on Monero (XMR).
+          A fork of Bisq redesigned exclusively for XMR/fiat and XMR/crypto trading.
+          Requires no KYC, no central server, and no registration. Trades are secured
+          using 2-of-3 multisig escrow with a network arbitrator. Available via
+          multiple community-run instances including RetosSwap and DawnSwap.
+
       notableMentions: |
         For traders, [BaseFEX](https://www.basefex.com/) doesn't require ID and has a good privacy policy.
 


### PR DESCRIPTION
## Summary

Adds [Haveno](https://haveno.exchange) to the **Crypto Exchanges** section.

## Why Haveno belongs here

- **Fully decentralized**: no central server, no company, no custodian. The protocol itself enforces trades.
- **No KYC, no registration**: users trade directly using only a wallet address.
- **2-of-3 multisig escrow**: funds are never held by a third party. Trades settle trustlessly.
- **Open source (AGPL-3.0)**: auditable codebase at [haveno-dex/haveno](https://github.com/haveno-dex/haveno).
- **Built on Monero**: inherits XMR privacy properties (stealth addresses, RingCT, Dandelion++) for all trades.
- **Actively developed and in production**: multiple live community instances (RetosSwap, DawnSwap) with real trading volume.
- **Fork of Bisq**: inherits a battle-tested architecture, redesigned for XMR-native operation.

Haveno is a strong fit for this list — it represents the privacy-preserving, self-sovereign alternative to KYC exchanges, fitting the spirit of the Crypto Exchanges section alongside Bisq, AtomicDEX, and RoboSats.

## Checklist

- [x] Entry follows existing YAML format (name, url, github, openSource, description)
- [x] Description is concise and factual
- [x] No existing Haveno entry in the file
- [x] Placed logically in the Crypto Exchanges section
