### PR TITLE
Add Haven Card to Virtual Credit Cards

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4733,15 +4733,14 @@ categories:
           numbers, virtual email addresses, messaging, private browsing, and more. There
           is a free plan for up to 3 identities, and premium plans start at $0.99/month.
 
-      - name: Haven
+      - name: Haven Card
         url: https://haven.hn
+        icon: https://cdn.prod.website-files.com/68a2a8a7de53d00447add222/68bb30e62327f0531c6d2d80_webclip.png
         acceptsCrypto: true
         description: |
-          A crypto-funded virtual card where your wallet address and card identity
-          are never linked. Deposit crypto, get a Mastercard for Apple Pay, Google Pay,
-          or Samsung Pay. The card provider handles KYC but never sees your on-chain
-          address, so there is no traceable connection between your wallet and your
-          spending. Supports Ethereum, Arbitrum, Base, and Fuel networks.
+          Crypto-funded virtual Mastercard where your wallet address and card identity
+          are never linked. Deposit crypto, get a card for Apple/Google/Samsung Pay.
+          Card provider handles KYC but never sees your on-chain address. Not open source yet.
 
 
     - name: Other Payment Methods

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4733,6 +4733,16 @@ categories:
           numbers, virtual email addresses, messaging, private browsing, and more. There
           is a free plan for up to 3 identities, and premium plans start at $0.99/month.
 
+      - name: Haven
+        url: https://haven.hn
+        acceptsCrypto: true
+        description: |
+          A crypto-funded virtual card where your wallet address and card identity
+          are never linked. Deposit crypto, get a Mastercard for Apple Pay, Google Pay,
+          or Samsung Pay. The card provider handles KYC but never sees your on-chain
+          address, so there is no traceable connection between your wallet and your
+          spending. Supports Ethereum, Arbitrum, Base, and Fuel networks.
+
 
     - name: Other Payment Methods
       services:


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds **Haven Card** to Finance > Virtual Credit Cards.

Haven Card is a crypto-funded virtual Mastercard that separates wallet identity from card identity. The card provider handles KYC but never sees the user's on-chain address, so there is no traceable link between wallet and spending.

This is a different product from "Haven" in Security Tools > Mobile Apps.

---

### Supporting Material

- Website: https://haven.hn
- App: https://app.haven.hn

---

### Affiliation

I am the co-founder of Haven.

---

### Note on open source

Haven is not open source yet. We acknowledge this is a core requirement for Awesome Privacy.

However, there is precedent in this same section: Privacy.com and Revolut Premium are both listed under Virtual Credit Cards and neither is open source. Haven's privacy architecture (wallet/card identity separation) is a meaningful differentiator in this category.

If the maintainers prefer, we're happy to move this entry to Notable Mentions instead.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)