### PR TITLE
Adds Proton Calendar to calendars section

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3196,7 +3196,21 @@ categories:
     ######################
     - name: Calendar
       alternativeTo: ['google calendar', 'microsoft outlook calendar', 'apple calendar', 'yahoo calendar']
-      services: []
+      services:
+      - name: Proton Calendar
+        url: https://proton.me/calendar
+        github: ProtonMail/android-calendar
+        tosdrId: 491
+        iosApp: https://apps.apple.com/us/app/proton-calendar-secure-events/id1514709943
+        androidApp: me.proton.android.calendar
+        subreddit: ProtonCalendar
+        acceptsCrypto: true
+        securityAudited: true
+        icon: https://calendar.proton.me/assets/android-chrome-256x256.png
+        description: |
+          The calendar app from the Proton suite. End-to-end encrypted.
+          Supports ICS (not encrypted), colours, recurring events, mail integration,
+          notifications and multiple time zones.
 
     ###########################
     ###### Backup & Sync ######


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds Proton Calendar under Calendars.

Re: #413 and #377 and #333

---

### Supporting Material
- Web (Proton): https://proton.me
- Web (Proton Calendar): https://proton.me/calendar
- Source (Android): https://github.com/ProtonMail/android-calendar
- Source (iOS): https://github.com/ProtonMail/ios-calendar
- Privacy Policy (Proton): https://proton.me/legal/privacy
- Privacy Policy (Proton Calendar): https://proton.me/calendar/privacy-policy

Previous security audit published here: https://drive.proton.me/urls/VGXYGFPE70#txnu5vF12qQU
They've just had a fresh audit done, although I've not found the report for this (yet).

#### Anti-Features:

To use their "Easy Switch" method to import calendar data from their Google/Gmail calendar, involves using the Sign in with Google feature. (this is fine, as doesn't appear to be used anywhere unless the user explicitly does a google import).

Proton has previously had controversy around IP logging (2019) and responding to a government metdata subpoena. (seems resolved, recent audit showed no logs)

More recently, they have been shipping a lot, and some users have concerns that they are moving away from their original goal of "secure and private email" and towards an "everything app".

---

### Affiliation
I am a semi user of ProtonMail.
I have made a past security report to Proton (2021).

---

### Checklist

- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

