### PR TITLE
Add Text Expansion section to Productivity category

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3191,6 +3191,40 @@ categories:
         [Laverna](https://laverna.cc/) is a cross-platform secure notes app,
         where all entries are formatted with markdown.
 
+    ############################
+    ###### Text Expansion ######
+    ############################
+    - name: Text Expansion
+      alternativeTo: ['TextExpander', 'PhraseExpress', 'Text Blaze', 'Briskine']
+      intro: >
+        Text expanders let you type short abbreviations that auto-expand into
+        full text - saving time on repetitive typing. Most mainstream options
+        store your text in plaintext on their servers. These alternatives keep
+        your data private.
+      services:
+      - name: Makro
+        url: https://makroexpander.com
+        followWith: Chrome, Firefox, Edge, Brave
+        icon: https://makroexpander.com/icons/icon-128.png
+        description: >
+          Free, privacy-first text expander for Chrome and Firefox. All macros
+          encrypted at rest with AES-256-GCM. Zero-knowledge cloud sync (Pro).
+          Local AI rewriting via Ollama. No account required. Supports 7
+          languages. Import from TextExpander, Espanso, PhraseExpress and more.
+
+      - name: Espanso
+        url: https://espanso.org
+        github: espanso/espanso
+        followWith: Windows, Mac, Linux
+        openSource: true
+        icon: https://espanso.org/img/logo.png
+        description: >
+          Free, open-source, cross-platform text expander written in Rust.
+          Works system-wide across all desktop apps via CLI. Configured through
+          YAML files. Supports regex triggers, shell commands, and community
+          packages. No encryption or cloud sync built in.
+
+
     ######################
     ###### Calendar ######
     ######################


### PR DESCRIPTION
## Addition: Text Expansion section

**Disclosure:** I am the developer of Makro.

### Why add this section?

Text expansion is a common productivity workflow (type a short abbreviation, get full text). The mainstream tools (TextExpander, PhraseExpress, Text Blaze, Briskine) store user data in plaintext on their servers or require accounts. Privacy-respecting alternatives exist but are not currently listed.

### Services added

1. **Makro** - Free browser extension (Chrome/Firefox) with AES-256-GCM encryption at rest, zero-knowledge cloud sync, and local AI via Ollama. No account required.

2. **Espanso** - Free, open-source (GPL-3.0) desktop text expander written in Rust. System-wide, CLI-based, fully auditable. Included for balance as the other major privacy-respecting option.

### Checklist
- [x] Description within 50-250 characters
- [x] Transparent about affiliation
- [x] Includes a non-affiliated alternative (Espanso) for balance
- [x] Valid YAML formatting
