### PR TITLE
Adds Redlib under Proxy Sites

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4907,6 +4907,15 @@ categories:
           Claims to encrypt traffic, but caution is advised for personal information. Managed by DevroLabs.
         url: https://weboproxy.com
 
+      - name: Redlib
+        description: |
+          An alternative private front-end to Reddit, with its origins in [Libreddit](https://github.com/libreddit/libreddit).
+          Has workarounds to access data without relying upon the restrictive Reddit API.
+        github: redlib-org/redlib
+        icon: https://raw.githubusercontent.com/redlib-org/redlib/refs/heads/main/static/logo.png
+        url: https://github.com/redlib-org/redlib
+        followWith: Reddit
+
       notableMentions:
       - name: NewPipe
         url: https://newpipe.schabi.org


### PR DESCRIPTION
### Type
Addition

---

### Changes

Adds Redlib, an alternative frontend and proxy for read-only browsing of Reddit.
Thanks @ltguillaume for suggesting this after the removal of Libreddit, in https://github.com/Lissy93/awesome-privacy/pull/434#issuecomment-4070046570

---

### Supporting Material

Just the code and docs from the GH repo: https://github.com/redlib-org/redlib
And a list of some public instances: https://stats.uptimerobot.com/mpmqAs1G2Q

---

### Additional Info

Worth briefly noting how this actually works in terms of getting around the API (which Reddit has discontinued/ made very expensive).
Redlib works by spoofing OAuth tokens from the official Reddit mobile and web clients, to impersonate a real user (via convincing looking user-agent, device IDs, headers and TLS cipher suites) to obtain a public OAuth token from Reddit's own endpoint.

So, that does mean that it has a few limitations:
1. It could break at any moment, if Reddit tightens their client fingerprinting or token validation.
2. It's read-only browsing, (afaik) you cannot authenticate to vote/comment/post/etc.
3. Certain features are not supported: Search, realtime, some media content (like HLS video)
4. Subscriptions are local-only, stored as cookie and not synced. And no way to view private subs/communities

In terms of privacy, the only point to note is that the opperator of the redlib instance you're using can see your browsing activity. Non issue, since you can self-host.

And in terms of security, I (as a mere js dev) see no major issues, beyond just that throughout the app it fully trusts whatever the Reddit API gives it, and renders directly. Should be totally fine, so long as we trust Reddit's sanitization.

---

### Affiliation
None.

---

### Checklist

- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

