### PR TITLE
Add Lockpaw to Mac OS Defences

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4277,6 +4277,13 @@ categories:
         description: |
           Kernel-level, OS-level, and client-level security for macOS. With a Firewall, Blackhole, and Privatizing Proxy for Trackers, Attackers, Malware, Adware, and Spammers; with On-Demand and On-Access Anti-Virus Scanning.
 
+      - name: Lockpaw
+        url: https://getlockpaw.com
+        github: sorkila/lockpaw
+        openSource: true
+        description: |
+          macOS menu bar screen guard that prevents visual eavesdropping and shoulder surfing. Instantly lock and unlock your screen with a global hotkey, with Touch ID as a fallback. Lightweight, free, and open source.
+
 
     ##########################
     ###### Anti-Malware ######


### PR DESCRIPTION
## Summary

Adding [Lockpaw](https://getlockpaw.com) to the **Mac OS Defences** section.

Lockpaw is a free, open source macOS menu bar screen guard that prevents visual eavesdropping and shoulder surfing. It lets you instantly lock and unlock your screen with a global hotkey, with Touch ID / password as a fallback for forgotten hotkeys.

- **Website:** https://getlockpaw.com
- **GitHub:** https://github.com/sorkila/lockpaw
- **License:** MIT
- **Open source:** Yes
- **Platform:** macOS 14+

### Why it fits Awesome Privacy

Lockpaw is a physical privacy tool — it protects against shoulder surfing and visual eavesdropping in public spaces (cafés, coworking, offices, transit). Unlike macOS's built-in screen lock (which requires re-authentication every time), Lockpaw uses a hotkey for instant lock/unlock, making it practical to toggle frequently throughout the day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)