### PR TITLE
Add Lockpaw to Mac OS Defences

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4277,6 +4277,13 @@ categories:
         description: |
           Kernel-level, OS-level, and client-level security for macOS. With a Firewall, Blackhole, and Privatizing Proxy for Trackers, Attackers, Malware, Adware, and Spammers; with On-Demand and On-Access Anti-Virus Scanning.
 
+      - name: Lockpaw
+        url: https://getlockpaw.com
+        github: sorkila/lockpaw
+        openSource: true
+        description: |
+          Lockpaw locks the screen while letting background tasks, builds, and AI agents keep running. A native macOS menu bar app that acts as a privacy shield for active workstations, blocking visual access and input without interrupting work.
+
 
     ##########################
     ###### Anti-Malware ######


### PR DESCRIPTION
## Summary

- Adds [Lockpaw](https://getlockpaw.com) to the **Mac OS Defences** section
- Lockpaw is a free, open-source macOS menu bar app that locks the screen while letting background tasks, builds, and AI agents keep running
- It acts as a privacy shield for active workstations, blocking visual access and input without interrupting work

## Details

| Field | Value |
|-------|-------|
| Website | https://getlockpaw.com |
| GitHub | [sorkila/lockpaw](https://github.com/sorkila/lockpaw) |
| Open Source | Yes |
| Platform | macOS |
| License | Open source, free |

🤖 Generated with [Claude Code](https://claude.com/claude-code)