### PR TITLE
Fixes icon for uBlock Origin

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2655,7 +2655,7 @@ categories:
       - name: uBlock Origin
         url: https://github.com/gorhill/uBlock
         github: gorhill/uBlock
-        icon: https://raw.githubusercontent.com/hectorm/hblock/master/resources/logo/bitmaps/logo-shield-ffffff-h512.png
+        icon: https://raw.githubusercontent.com/gorhill/uBlock/master/src/img/ublock.svg
         followWith: Browser
         description: |
           Light-weight, fast browser extension for Firefox and Chromium (Chrome, Edge, Brave Opera etc), that blocks


### PR DESCRIPTION
### Type
Amendment

---

### Changes
Fixed icon path for ad-blockers --> uBlock Origin, as raised by @Jaoheah in #449
Previously, it was pointing to hBlock's logo for some unknown mystry reason 👻

---

### Supporting Material
Correct icon path: https://raw.githubusercontent.com/gorhill/uBlock/master/src/img/ublock.svg
Page in awesome privacy: https://awesome-privacy.xyz/networking/ad-blockers/ublock-origin

---

### Affiliation
None

---

### Checklist

- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

