### PR TITLE
Add MapAtlas to Maps & Navigation

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3804,6 +3804,25 @@ categories:
         use to securely remove files or directories, just run `srm -zsv /path/to/file`
         for a single pass over.
 
+    ##################################
+    ###### Maps & Navigation ########
+    ##################################
+    - name: Maps & Navigation
+      alternativeTo: ['Google Maps', 'Apple Maps', 'Mapbox']
+      intro: |
+        Privacy-respecting mapping services and APIs that do not track users
+        or log personal data.
+      services:
+      - name: MapAtlas
+        url: https://mapatlas.eu
+        icon: https://mapatlas.eu/favicon.ico
+        description: >-
+          European privacy-first mapping API providing geocoding, routing, and map tiles.
+          EU-hosted with GDPR compliance, ISO 27001 certification, no user tracking,
+          and no IP logging.
+        openSource: false
+        securityAudited: true
+
 
 
   - name: Operating Systems


### PR DESCRIPTION
## Type
Addition

## Changes
Adding MapAtlas as a privacy-respecting mapping API alternative under a new "Maps & Navigation" section in the Utilities category.

## Supporting Material
- Website: https://mapatlas.eu
- EU-hosted, GDPR compliant, ISO 27001 certified
- No user tracking, no IP logging
- Free tier: 10k map loads/month

## Affiliation
I am affiliated with MapMetrics B.V., the company behind MapAtlas.

## Checklist
- [x] I have read the Contributing Guidelines
- [x] The service is privacy-respecting
- [x] I have disclosed my affiliation