### PR TITLE
Removes WinAuth

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -226,17 +226,6 @@ categories:
           Simple, native, open source 2-FA Client for iOS, which never connects to the
           internet - built by @mattrubin.me
 
-      - name: WinAuth
-        url: https://winauth.github.io/winauth
-        github: winauth/winauth
-        icon: https://winauth.github.io/winauth/favicon.ico
-        followWith: Windows
-        description: |
-          Portable, encrypted desktop authenticator app for Microsoft Windows. With
-          useful features, like hotkeys and some additional security tools, WinAuth is a
-          great companion authenticator for desktop power-users. It's open source and
-          well-established (since mid-2010)
-
       - name: Authenticator GNOME
         url: https://gitlab.gnome.org/World/Authenticator
         icon: https://gitlab.gnome.org/World/Authenticator/-/avatar?width=48


### PR DESCRIPTION
### Type
Removal

---

### Changes
Removes WinAuth

---

### Supporting Material
Removing as repo archived, so the project is no longer patched or maintained

See #368 
RIP WinAuth 🪦

There is a _slightly_ more maintained fork over at: https://github.com/ttodua/winauth-revived
But will wait and see if it keeps getting updates before including it here.

---

### Affiliation
None.

---

### Checklist

- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
