### PR TITLE
Add fileGOD to File Converters

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -4311,12 +4311,6 @@ TikTok, and more.*
 		[![GitHub: FFmpeg/FFmpeg](https://img.shields.io/github/stars/FFmpeg/FFmpeg?style=flat&logo=github&label=FFmpeg&color=%235f53f4&cacheSeconds=3600)](https://github.com/FFmpeg/FFmpeg) [![FFmpeg on Awesome Privacy](https://img.shields.io/badge/View%20Report-FC60A8?style=flat&logo=awesomelists&label=FFmpeg)](https://awesome-privacy.xyz/media/file-converters/ffmpeg) [![Open Source](https://img.shields.io/badge/-Open_Source-3DA639?style=flat&logo=opensourceinitiative&logoColor=white)](https://github.com/FFmpeg/FFmpeg)ㅤ 
 
 		</details>
-		
-- **[fileGOD](https://filegod.app)** - 37 browser-based tools for PDFs and images (compress, convert, merge, split, resize, OCR, QR codes). All processing runs client-side via WebAssembly. No files ever leave your device. 25 languages, works offline as PWA. Open source core.
-	- <details>
-		<summary>Stats</summary>
-		[![GitHub: fileGOD/file-tools](https://img.shields.io/github/stars/fileGOD/file-tools?style=flat&logo=github&label=file-tools&color=%235f53f4&cacheSeconds=3600)](https://github.com/fileGOD/file-tools) [![Open Source](https://img.shields.io/badge/-Open_Source-3DA639?style=flat&logo=opensourceinitiative&logoColor=white)](https://github.com/fileGOD/file-tools)ㅤ
-		</details>
 
 <p align="right"><sup><a href="#top">⬆️ [Back to Top]</a></sub></p>
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -4311,6 +4311,12 @@ TikTok, and more.*
 		[![GitHub: FFmpeg/FFmpeg](https://img.shields.io/github/stars/FFmpeg/FFmpeg?style=flat&logo=github&label=FFmpeg&color=%235f53f4&cacheSeconds=3600)](https://github.com/FFmpeg/FFmpeg) [![FFmpeg on Awesome Privacy](https://img.shields.io/badge/View%20Report-FC60A8?style=flat&logo=awesomelists&label=FFmpeg)](https://awesome-privacy.xyz/media/file-converters/ffmpeg) [![Open Source](https://img.shields.io/badge/-Open_Source-3DA639?style=flat&logo=opensourceinitiative&logoColor=white)](https://github.com/FFmpeg/FFmpeg)ㅤ 
 
 		</details>
+		
+- **[fileGOD](https://filegod.app)** - 37 browser-based tools for PDFs and images (compress, convert, merge, split, resize, OCR, QR codes). All processing runs client-side via WebAssembly. No files ever leave your device. 25 languages, works offline as PWA. Open source core.
+	- <details>
+		<summary>Stats</summary>
+		[![GitHub: fileGOD/file-tools](https://img.shields.io/github/stars/fileGOD/file-tools?style=flat&logo=github&label=file-tools&color=%235f53f4&cacheSeconds=3600)](https://github.com/fileGOD/file-tools) [![Open Source](https://img.shields.io/badge/-Open_Source-3DA639?style=flat&logo=opensourceinitiative&logoColor=white)](https://github.com/fileGOD/file-tools)ㅤ
+		</details>
 
 <p align="right"><sup><a href="#top">⬆️ [Back to Top]</a></sub></p>
 

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4962,8 +4962,8 @@ categories:
           split, resize, OCR, QR codes). All processing runs client-side via
           WebAssembly. No files ever leave your device. 25 languages, works
           offline as PWA. Open source core.
-       github: fileGOD/file-tools
-       openSource: true
+        github: fileGOD/file-tools
+        openSource: true
 
   - name: Creativity
     sections:

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4954,6 +4954,16 @@ categories:
           video. It's the industry standard multimedia framework, handling a vast range
           of formats. As a command-line tool, it guarantees that all processing is done
           locally on your machine.
+      - name: fileGOD
+        url: https://filegod.app
+        icon: https://filegod.app/favicon.ico
+        description: >-
+          37 browser-based tools for PDFs and images (compress, convert, merge,
+          split, resize, OCR, QR codes). All processing runs client-side via
+          WebAssembly. No files ever leave your device. 25 languages, works
+          offline as PWA. Open source core.
+       github: fileGOD/file-tools
+       openSource: true
 
   - name: Creativity
     sections:


### PR DESCRIPTION
### Type
Addition
---
### Changes
Adding fileGOD to the File Converters section. Browser-based file processing platform with 37 tools for PDFs and images. All processing runs client-side via WebAssembly, no files are ever uploaded to any server.
---
### Supporting Material
- Website: https://filegod.app
- Source code: https://github.com/fileGOD/file-tools (MIT license)
- Live demo: https://filegod.app (open DevTools Network tab to verify zero uploads)
---
### Affiliation
I am the founder of fileGOD.
---
### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

