### PR TITLE
Adds new section for paste bins/ secret sharing

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1167,7 +1167,7 @@ categories:
         description: |
           Anonymous SMS service able to activate accounts. Accessible over web, CLI, or
           email. Pricing starts at $3.60 / month. The service is in beta as of 2022.
-          
+
       - name: PikaSim
         url: https://pikasim.com
         icon: https://pikasim.com/img/pika-transparent.png
@@ -1190,10 +1190,10 @@ categories:
         url: https://narayana.im
         icon: https://git.narayana.im/avatars/72d9e4a07b9e42917b7face86d544517
         description: |
-          Anonymous physical SIMs, eSIMs, VoIP phone numbers, and other advanced features. 
-          Inbound/outbound calls, SMS and roaming internet. Very private, has a Tor mirror, 
+          Anonymous physical SIMs, eSIMs, VoIP phone numbers, and other advanced features.
+          Inbound/outbound calls, SMS and roaming internet. Very private, has a Tor mirror,
           accepts crypto, doesn't KYC and you can delete your logs.
-        acceptsCrypto: true  
+        acceptsCrypto: true
 
     ################################
     ###### Team Collaboration ######
@@ -1953,15 +1953,6 @@ categories:
             A tool from Netcraft, for analysing what any given website is running, where it's located and information about its
             host, registrar, IP and SSL certificates.
 
-        - name: Hemmelig.app
-          url: https://hemmelig.app/
-          icon: https://hemmelig.app/icons/icon-512x512.png
-          openSource: true
-          github: HemmeligOrg/Hemmelig.app
-          description: |
-            Share rich text and files securely with locally encrypted messages that automatically self-destruct, or
-            invite others to send you a secret. Allows setting maximum views, webhooks, expiration times and IP restrictions.
-            Open source and self-hostable.
 
       wordOfWarning: >
         Browsers are inherently insecure, be careful when uploading, or entering personal details.
@@ -3363,6 +3354,23 @@ categories:
         You could also run a local server that you physically own at a secondary location,
         that would mitigate the need to trust a third party cloud provider.
         Note that some knowledge in securing networks is required.
+
+
+    ############################################
+    ###### Paste Bins and Secret Sharing ######
+    ###########################################
+    - name: Secret Sharing
+      alternativeTo: ['pastebin', 'hastebin', 'ghostbin', 'justpaste.it']
+      services:
+      - name: Hemmelig.app
+        url: https://hemmelig.app/
+        icon: https://hemmelig.app/icons/icon-512x512.png
+        openSource: true
+        github: HemmeligOrg/Hemmelig.app
+        description: |
+          Share rich text and files securely with locally encrypted messages that automatically self-destruct, or
+          invite others to send you a secret. Allows setting maximum views, webhooks, expiration times and IP restrictions.
+          Open source and self-hostable.
 
 
     ########################


### PR DESCRIPTION
### Type
Amendment

---

### Changes
Adds a new section for secret sharing platforms under Productivity, to allow for encrypted paste bin type services.
Also moved Hemmelig into this new section, and will later add probably add crypt.fyi from #307 here too.

Note: The diff is showing some other changes around PikaSim entry, but this was just YAML prettier fixes, no actual content changed.

---

### Supporting Material
N/A

---

### Affiliation
None.

---

### Checklist

- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

