### PR TITLE
Add Locally Uncensored to AI Tools section

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5264,4 +5264,16 @@ categories:
         github: https://github.com/aseprite/aseprite
         openSource: true
 
-
+  - name: AI Tools
+    sections:
+    - name: Local AI Assistants
+      services:
+      - name: Locally Uncensored
+        description: |
+          An all-in-one local AI desktop app for uncensored chat, image generation, and video
+          creation. Built with Tauri, it uses Ollama for LLM inference and ComfyUI for media
+          generation workflows. All processing runs entirely on your own hardware, ensuring
+          complete privacy with no data sent to external servers.
+        url: https://github.com/PurpleDoubleD/locally-uncensored
+        github: PurpleDoubleD/locally-uncensored
+        openSource: true


### PR DESCRIPTION
Adds **Locally Uncensored** as a new entry under a new AI Tools category.

Locally Uncensored is a free, open-source (MIT) desktop app that runs AI chat, image generation, and video creation entirely locally on your hardware using Ollama and ComfyUI. No data is sent to external servers, making it a strong fit for this privacy-focused list.

- GitHub: https://github.com/PurpleDoubleD/locally-uncensored
- All processing is 100% local - no cloud, no telemetry
- License: MIT
