### PR TITLE
security: restrict CORS origins to whitelisted domains

### DIFF
--- a/api/src/api.ts
+++ b/api/src/api.ts
@@ -16,7 +16,15 @@ import index from '../public/index.html'
 const app = new Hono({ strict: false });
 
 /* Enable CORS for all routes */
-app.use('*', cors());
+app.use('*', cors({
+  origin: [
+    'https://awesome-privacy.xyz',
+    'https://api.awesome-privacy.xyz',
+    'https://api.awesomeprivacy.com',
+    'https://awesome-privacy.as93.workers.dev',
+    'http://localhost:9000',
+  ],
+}));
 
 /* Serve the index page (which contains the Swagger Docs) */
 app.get("/", async (ctx) => {


### PR DESCRIPTION
Replaced the permissive wildcard CORS configuration with an explicit list of allowed origins in the Hono API to enhance security and prevent unauthorized cross-origin access.

The whitelist includes production domains and the local development port (9000).


<!--
Thank you for contributing to Awesome-Privacy! 🙌
Before submitting, please read .github/CONTRIBUTING.md, 
And ensure that your pull request follows the guidelines.
-->

### Type
<!-- Delete as appropriate. This is used to auto-apply labels. -->

Addition / Amendment / Removal / Spelling or Grammar / Website Update / Misc

---

### Changes
<!-- Briefly outline your changes, and if necessary explain why -->

---

### Supporting Material
<!-- For new entries, provide relevant links. E.g. Git repo, security audit, docs, etc -->

---

### Affiliation
<!--
For transparency, please indicate whether or not you are associated with the software being added / edited.
If this is a deletion, you should also disclose your affiliation with and other project within the same category.
-->

---

### Checklist

- [ ] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [ ] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [ ] I have indicated whether I have any affiliation with any software / services added  
- [ ] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

