### PR TITLE
[Add] SecretNotes in Secret Sharing

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3401,13 +3401,12 @@ categories:
           encryption, HKDF key derivation, CLI tool, and Docker self-hosting.
       
       - name: SecretNotes
-          url: https://secretnotes.pro
-          icon: https://secretnotes.pro/favicon.ico
-          openSource: false
-          description: |
-            Zero-knowledge encrypted notes platform with built-in encrypted messenger.
-            Uses AES-256-GCM client-side encryption, burn-after-read, expiry timers,
-            and secure request/response flows. Encryption keys never leave the browser.
+        url: https://secretnotes.pro
+        icon: https://secretnotes.pro/favicon.ico
+        description: |
+          Zero-knowledge encrypted notes platform with built-in encrypted messenger.
+          Uses AES-256-GCM client-side encryption, burn-after-read, expiry timers,
+          and secure request/response flows. Encryption keys never leave the browser.
 
 
     ########################

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3399,6 +3399,16 @@ categories:
         description: |
           1time.io - Zero-knowledge one-time secret sharing with AES-256-GCM browser-side
           encryption, HKDF key derivation, CLI tool, and Docker self-hosting.
+      
+      - name: SecretNotes
+          url: https://secretnotes.pro
+          icon: https://secretnotes.pro/favicon.ico
+          openSource: false
+          description: |
+            Zero-knowledge encrypted notes platform with built-in encrypted messenger.
+            Uses AES-256-GCM client-side encryption, burn-after-read, expiry timers,
+            and secure request/response flows. Encryption keys never leave the browser.
+
 
     ########################
     ###### File Drop ######


### PR DESCRIPTION
### Type
  Addition

  ### Changes
  Adds SecretNotes to the Secret Sharing section. SecretNotes is a zero-knowledge encrypted notes platform with
  AES-256-GCM client-side encryption, burn-after-read, and built-in encrypted messenger.

  ### Checklist
  - [x] I have read the [Contributing
  Guidelines](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md)
  - [x] I have checked that this service is not already listed
  - [x] I have only modified `awesome-privacy.yml`
  - [x] I agree to follow the Code of Conduct