### PR TITLE
Add amneziawg-installer to Self-Hosted Network Security

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2139,6 +2139,16 @@ categories:
         description: |
           Open-source self-hosted VPN and firewall built on WireGuard®.
 
+      - name: amneziawg-installer
+        url: https://github.com/bivlked/amneziawg-installer
+        github: bivlked/amneziawg-installer
+        icon: https://avatars.githubusercontent.com/u/50226185
+        openSource: true
+        description: |
+          One-command installer for self-hosted AmneziaWG 2.0 VPN on Ubuntu and Debian servers.
+          Uses protocol mimicry to bypass DPI censorship. Includes client management, QR codes,
+          and resume-after-reboot. CLI-only, requires a dedicated server.
+
     ####################################
     ###### Anonymity/Mix networks ######
     ####################################


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds [amneziawg-installer](https://github.com/bivlked/amneziawg-installer) to the **Self-Hosted Network Security** section, alongside PiVPN and Firezone.

amneziawg-installer is a one-command automated installer for [AmneziaWG 2.0](https://docs.amnezia.org/documentation/amnezia-wg/) VPN on Ubuntu and Debian servers. AmneziaWG is a WireGuard-based protocol with built-in traffic obfuscation that makes VPN traffic resistant to deep packet inspection (DPI) — designed for use in countries with internet censorship.

The entry is placed at the end of the Self-Hosted Network Security section.

---

### Supporting Material

- **Repository:** https://github.com/bivlked/amneziawg-installer (180+ stars, MIT license)
- **Protocol docs:** https://docs.amnezia.org/documentation/amnezia-wg/
- **Advanced documentation:** https://github.com/bivlked/amneziawg-installer/blob/main/ADVANCED.md

---

### Affiliation

I am the author and maintainer of amneziawg-installer.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)