### PR TITLE
Add oudenOS to Windows Defences

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4158,6 +4158,15 @@ categories:
           (It uses the Windows API to interact with key features of Local Group
           Police, Services, Tasks Scheduler, etc).
 
+      - name: oudenOS
+        url: https://ouden.cc
+        github: redpersongpt/oudenOS
+        openSource: true
+        description: |
+          Hardware-aware Windows optimizer that scans your system, profiles it into
+          one of eight hardware types, and removes bloatware with per-action rollback.
+          Blocks 70 telemetry endpoints, disables 220+ unnecessary services. 5MB, built with Rust.
+
       - name: GhostPress
         url: https://schiffer.tech/ghostpress.html
         icon: https://schiffer.tech/img/logos/gp.png


### PR DESCRIPTION
## oudenOS — Windows Defences

**Website:** https://ouden.cc  
**GitHub:** https://github.com/redpersongpt/oudenOS  
**License:** GPL-3.0  
**Open Source:** Yes

Hardware-aware Windows optimizer that blocks 70 telemetry endpoints, removes 220+ unnecessary services, and provides per-action rollback. Scans hardware first, profiles into 8 types, shows every change before applying. 5MB, built with Rust + Tauri.

Edited only `awesome-privacy.yml` as per contributing guidelines. Added to `Windows Defences` section.