### PR TITLE
Add Fluranto Remove Image Metadata to Metadata Removal

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3721,6 +3721,12 @@ categories:
         description: |
           Native MacOS app, with drag 'n drop image optimization and meta data removal.
 
+      - name: Fluranto Remove Image Metadata
+        url: https://www.fluranto.com/en/image/remove-image-metadata
+        description: |
+          Browser-based image metadata remover that strips EXIF data locally in your browser.
+          No signup required, privacy-first, and files are processed client-side.
+
       notableMentions: |
         It's possible (but slower) to do this without a third-party tool.
         For Windows, right click on a file, and go to: `Properties --> Details --> Remove Properties --> Remove from this File --> Select All --> OK`.


### PR DESCRIPTION
### Type

Addition

---

### Changes

Added Fluranto Remove Image Metadata to the Metadata Removal section.

Fluranto Remove Image Metadata is a browser-based tool that removes EXIF/image metadata locally in the browser, with no signup required.

---

### Supporting Material

Tool URL:
https://www.fluranto.com/en/image/remove-image-metadata

---

### Affiliation

I am affiliated with Fluranto.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)