### PR TITLE
Add Typer to Voice Assistants

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4396,7 +4396,13 @@ categories:
       services: []
 
     - name: Developer Utilities
-      services: []
+      services:
+      - name: Typer
+        url: https://typer.space
+        description: |
+          Free local AI chat app for macOS (Apple Silicon). Runs entirely on-device —
+          no account, no cloud, no ads. Works fully offline with on-device web search.
+          Download from the Mac App Store, no setup required.
 
   - name: Smart Home & IoT
     sections:
@@ -4411,13 +4417,7 @@ categories:
         For that reason it is recommended not to have these devices in your house.
         The following are open source AI voice assistants, that aim to provide a
         human voice interface while also protecting your privacy and security
-      services:
-      - name: Typer
-        url: https://typer.space
-        description: |
-          Free local AI chat app for macOS (Apple Silicon). Runs entirely on-device —
-          no account, no cloud, no ads. Works fully offline with on-device web search.
-          Download from the Mac App Store, no setup required.
+      services: []
 
       notableMentions: |
         [Mycroft](https://github.com/MycroftAI/mycroft-core) and [Kalliope](https://github.com/kalliope-project/kalliope) removed, as no longer active.

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4411,7 +4411,13 @@ categories:
         For that reason it is recommended not to have these devices in your house.
         The following are open source AI voice assistants, that aim to provide a
         human voice interface while also protecting your privacy and security
-      services: []
+      services:
+      - name: Typer
+        url: https://typer.space
+        description: |
+          Free local AI chat app for macOS (Apple Silicon). Runs entirely on-device —
+          no account, no cloud, no ads. Works fully offline with on-device web search.
+          Download from the Mac App Store, no setup required.
 
       notableMentions: |
         [Mycroft](https://github.com/MycroftAI/mycroft-core) and [Kalliope](https://github.com/kalliope-project/kalliope) removed, as no longer active.

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4396,13 +4396,7 @@ categories:
       services: []
 
     - name: Developer Utilities
-      services:
-      - name: Typer
-        url: https://typer.space
-        description: |
-          Free local AI chat app for macOS (Apple Silicon). Runs entirely on-device —
-          no account, no cloud, no ads. Works fully offline with on-device web search.
-          Download from the Mac App Store, no setup required.
+      services: []
 
   - name: Smart Home & IoT
     sections:
@@ -4417,7 +4411,17 @@ categories:
         For that reason it is recommended not to have these devices in your house.
         The following are open source AI voice assistants, that aim to provide a
         human voice interface while also protecting your privacy and security
-      services: []
+      services:
+      - name: Typer
+        url: https://typer.space
+        icon: https://typer.space/public/app-icon.png
+        openSource: false
+        iosApp: https://apps.apple.com/app/typer-ai/id6751274483
+        followWith: macOS (Apple Silicon)
+        description: |
+          Free, private AI chat app for macOS that runs entirely on-device.
+          No account, no cloud, no ads. Works fully offline with local web search.
+          Not open source, but no data leaves the device.
 
       notableMentions: |
         [Mycroft](https://github.com/MycroftAI/mycroft-core) and [Kalliope](https://github.com/kalliope-project/kalliope) removed, as no longer active.


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds [Typer](https://typer.space) to **Smart Home & IoT > Voice Assistants** as a privacy-respecting AI assistant for macOS.

Typer is a free AI chat app that runs entirely on-device (Apple Silicon Macs). No account, no cloud, no ads. It also supports local web search without sending queries to external servers.

**On the open source requirement:** Typer is not open source. This is disclosed transparently via `openSource: false` in the listing and noted in the description. The repo already includes other non-open-source entries where justified (e.g. Startpage, Mojeek, ProtonMail, Mailfence). Typer's privacy model is architectural: the AI model runs locally on the user's Mac and no data leaves the device, which fits the spirit of this list. If this is a hard requirement, happy to move the entry to `notableMentions` instead.

**On category placement:** Voice Assistants is the closest existing section for a privacy-respecting AI assistant. The section's `notableMentions` already references desktop-based assistants (Dragonfire, Jarvis). Typer is text-based rather than voice-based. Happy to move it if the maintainer prefers a different section.

---

### Supporting Material
- Website: https://typer.space
- Mac App Store: https://apps.apple.com/app/typer-ai/id6751274483

---

### Affiliation
I am the developer of Typer.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)