### PR TITLE
Add Cunicula to Crypto Exchanges notable mentions

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4610,6 +4610,11 @@ categories:
         For buying and selling alt-coins, [Binance](https://www.binance.com/en/register?ref=X2BHKID1) has a wide range of currencies,
         ~and ID verification is not needed for small-value trades~ but ID verification is required in most countries.
 
+        [Cunicula](https://cunicula.com) is a curated directory of no-KYC and privacy-first services,
+        including crypto exchanges, swap services, P2P markets, and non-custodial wallets. Each entry
+        is tagged with its KYC level, jurisdiction, supported payment methods, and a trust score
+        reflecting warrant canaries, audit history, and known incidents.
+
     - name: Virtual Credit Cards
       alternativeTo: ['visa', 'mastercard', 'american express', 'discover', 'capital one']
       intro: |

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4613,7 +4613,7 @@ categories:
         [Cunicula](https://cunicula.com) is a curated directory of no-KYC and privacy-first services,
         including crypto exchanges, swap services, P2P markets, and non-custodial wallets. Each entry
         is tagged with its KYC level, jurisdiction, supported payment methods, and a trust score
-        reflecting warrant canaries, audit history, and known incidents.
+        reflecting audit history and known incidents.
 
     - name: Virtual Credit Cards
       alternativeTo: ['visa', 'mastercard', 'american express', 'discover', 'capital one']


### PR DESCRIPTION
### Type

Amendment

---

### Changes

Adds [Cunicula](https://cunicula.com) as a notable mention under **Finance → Crypto Exchanges**. Four lines appended to the existing `notableMentions` block in `awesome-privacy.yml` — no new top-level service entry.

Cunicula is a curated directory of no-KYC and privacy-first services covering exchanges, swap services, P2P markets, non-custodial wallets, and adjacent privacy tools. Each entry is tagged with KYC level, jurisdiction, supported payment methods, and a trust score reflecting audit history and known incidents.

The Crypto Exchanges section already discusses KYC verification requirements, so a pointer to a dedicated no-KYC index felt like a natural fit for readers looking for alternatives to the existing Binance/BitMex-style mentions. Happy to reshape, shorten, or move it elsewhere if preferred.

---

### Supporting Material

- Site: https://cunicula.com
- Directory covers 138 services across exchanges, wallets, VPNs, email, hosting, and comms
- Open source maintained, no paid placements, no affiliate links in entries

---

### Affiliation

Yes — I maintain Cunicula. Disclosing upfront. The mention is intentionally scoped to a single paragraph inside an existing `notableMentions` block rather than a top-level service listing, to avoid promotional framing.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
