### PR TITLE
Add PureMac to Mac OS Defences

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4311,6 +4311,16 @@ categories:
         description: |
           Kernel-level, OS-level, and client-level security for macOS. With a Firewall, Blackhole, and Privatizing Proxy for Trackers, Attackers, Malware, Adware, and Spammers; with On-Demand and On-Access Anti-Virus Scanning.
 
+      - name: PureMac
+        url: https://github.com/momenbasel/PureMac
+        icon: https://raw.githubusercontent.com/momenbasel/PureMac/main/PureMac/Assets.xcassets/AppIcon.appiconset/icon_128.png
+        github: momenbasel/PureMac
+        openSource: true
+        description: |
+          Privacy-respecting macOS system cleaner with zero telemetry, analytics, or network calls.
+          Cleans caches, Xcode junk, mail attachments, Homebrew cache, and finds large/old files.
+          A transparent alternative to CleanMyMac and similar tools that phone home.
+
 
     ##########################
     ###### Anti-Malware ######


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds [PureMac](https://github.com/momenbasel/PureMac) to the **Mac OS Defences** section.

PureMac is a free, open-source macOS system cleaner built with SwiftUI (MIT licensed). Its key privacy differentiator is that it makes **zero network calls** - no telemetry, no analytics, no phoning home whatsoever. It cleans system caches, user caches, Xcode junk, mail attachments, Homebrew cache, purgeable space, and helps find large/old files. Includes scheduled auto-cleaning.

A privacy-respecting alternative to CleanMyMac and similar commercial cleaners that collect usage data.

---

### Supporting Material

- **Source code**: https://github.com/momenbasel/PureMac
- **License**: MIT
- **Install**: `brew tap momenbasel/tap && brew install --cask puremac`

---

### Affiliation

I am the author and maintainer of PureMac.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)