### PR TITLE
Add CookieBoss to Online Tools

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1953,6 +1953,14 @@ categories:
             A tool from Netcraft, for analysing what any given website is running, where it's located and information about its
             host, registrar, IP and SSL certificates.
 
+        - name: CookieBoss
+          url: https://cookieboss.io
+          icon: https://cookieboss.io/favicon.svg
+          description: |
+            Edge-compiled cookie consent management with Google Consent Mode v2 support.
+            Scripts are compiled per-site on Cloudflare edge for minimal performance impact,
+            giving users real control over tracking consent.
+
       wordOfWarning: >
         Browsers are inherently insecure, be careful when uploading, or entering personal details.
 


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds CookieBoss to the **Online Tools** section under **Security Tools**. CookieBoss is an edge-compiled cookie consent management platform with Google Consent Mode v2 support. Consent scripts are compiled per-site on Cloudflare's edge network, minimizing performance impact while giving users genuine control over tracking consent.

---

### Supporting Material

- **Website:** https://cookieboss.io
- **How it works:** Each customer's consent script is compiled and served from Cloudflare edge (Workers + R2), so there is no third-party tracking or data collection by the platform itself. Consent choices are stored locally and enforced before any tags fire.

Note: The source code is not currently public. This is a commercial product with a privacy-first architecture — no user tracking data leaves the site, consent state is client-side only, and scripts contain no analytics or telemetry.

---

### Affiliation

I am the creator of CookieBoss.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)