### PR TITLE
Add SammaPix — privacy-first browser-based image toolkit (27 tools)

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5091,6 +5091,18 @@ categories:
         github: Beep6581/RawTherapee
         icon: https://icons.iconarchive.com/icons/papirus-team/papirus-apps/256/rawtherapee-icon.png
         openSource: true
+      - name: SammaPix
+        followWith: Web
+        description: |
+          A free, privacy-first image toolkit with 27 browser-based tools including
+          compress, resize, convert (HEIC/WebP/AVIF/JXL), background removal, passport
+          photos, AI rename, and batch watermark. All processing runs entirely in the
+          browser via Canvas API and WebAssembly — images are never uploaded to any server.
+          No signup required.
+        url: https://www.sammapix.com
+        github: samma1997/sammapix
+        icon: https://www.sammapix.com/favicon.ico
+        openSource: false
       - name: PhotoPea
         followWith: Web
         description: |


### PR DESCRIPTION
## What is SammaPix?

[SammaPix](https://www.sammapix.com) is a free, privacy-first image toolkit with **27 browser-based tools**. All processing runs entirely in the browser via Canvas API and WebAssembly — **images are never uploaded to any server**.

## Why it belongs in Awesome Privacy

- **100% client-side processing** — every tool runs in the browser, nothing is uploaded
- **Zero cookies, zero tracking** — no analytics, no ads on the free tier
- **No signup required** — every tool works immediately without an account
- **No data retention** — images exist only in the user's browser memory

## Tools included

Compress, resize, convert (HEIC/WebP/AVIF/JXL), AI background removal (RMBG-1.4 via WASM), passport photos (140+ countries), AI rename, batch watermark, duplicate finder, EXIF/GPS metadata removal, and more.

## Section

Added to **Creativity > Image Editors**, alongside GIMP, Inkscape, Paint.NET, Pixlr, RawTherapee, and PhotoPea.

## Links

- Website: https://www.sammapix.com
- Privacy approach: https://www.sammapix.com/blog/browser-based-image-tools-privacy-guide