### PR TITLE
Rename Mix Networks to Anonymity Networks (#490)

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2168,10 +2168,10 @@ categories:
         description: |
           Open-source self-hosted VPN and firewall built on WireGuard®.
 
-    ##########################
-    ###### Mix networks ######
-    ##########################
-    - name: Mix Networks
+    ####################################
+    ###### Anonymity/Mix networks ######
+    ####################################
+    - name: Anonymity Networks
       services:
       - name: Tor
         url: https://www.torproject.org
@@ -3094,7 +3094,7 @@ categories:
         openSource: true
         description: |
           A free, open-source note-taking application built with Qt, focused on providing a pleasant Markdown
-          editing experience. It manages notes directly as plain text files on your local system. 
+          editing experience. It manages notes directly as plain text files on your local system.
 
       notableMentions: |
         If you are already tied into Evernote, One Note etc, then [SafeRoom](https://www.getsaferoom.com)


### PR DESCRIPTION
### Type
Amendment

---

### Changes
Renames Mix Networks to Anonymity Networks, which is a more correct definition here
Fixes #490

---

### Supporting Material

[Untraceable Electronic Mail, Return Addresses, and Digital Pseudonyms](https://chaum.com/wp-content/uploads/2022/09/UNTRACEABLE-ELECTRONIC-MAIL-RETURN-ADDRESSES-AND-DIGITAL-PSEUDONYMS-tech-report.pdf)
David Chaum, 1981 - _Communications of the ACM_, Vol. 24, No. 2, pp. 84-90

---

### Affiliation
N/A

---

### Checklist

- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

