### PR TITLE
Adds Lemmy to Social Networks

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4806,6 +4806,13 @@ categories:
         url: https://www.minds.com
         github: minds/minds
 
+      - name: Lemmy
+        description: |
+          A federated, open-source link aggregator and discussion platform, similar to Reddit.
+          Built on ActivityPub. Wide range of cross-platform [client apps](https://join-lemmy.org/apps).
+        url: https://join-lemmy.org
+        github: LemmyNet/lemmy
+
       notableMentions: |
         - [diaspora\*](https://diasporafoundation.org), [Pleroma](https://pleroma.social), [Friendica](https://friendi.ca) and [Hubzilla ](https://hubzilla.org) - distributed, decentralized social networks, built on open protocols
         - [Tildes](https://tildes.net), [Lemmy](https://dev.lemmy.ml) and [notabug.io](https://notabug.io) - bulletin boards and news aggregators (similar to Reddit)

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4807,11 +4807,13 @@ categories:
         github: minds/minds
 
       - name: Lemmy
+        url: https://join-lemmy.org
+        github: LemmyNet/lemmy
+        icon: https://join-lemmy.org/static/assets/icons/apple-touch-icon.png
         description: |
           A federated, open-source link aggregator and discussion platform, similar to Reddit.
           Built on ActivityPub. Wide range of cross-platform [client apps](https://join-lemmy.org/apps).
-        url: https://join-lemmy.org
-        github: LemmyNet/lemmy
+        androidApp: com.jerboa
 
       notableMentions: |
         - [diaspora\*](https://diasporafoundation.org), [Pleroma](https://pleroma.social), [Friendica](https://friendi.ca) and [Hubzilla ](https://hubzilla.org) - distributed, decentralized social networks, built on open protocols


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds Lemmy to social networks section

---

### Supporting Material
- Main repo: https://github.com/LemmyNet/lemmy
- Public homepage: https://join-lemmy.org/
- Usage: Self-hostable (via [docker](https://join-lemmy.org/docs/administration/install_docker.html) / [Ansible](https://github.com/LemmyNet/lemmy-ansible) / [AWS](https://join-lemmy.org/docs/administration/on_aws.html) / [from scratch](https://join-lemmy.org/docs/administration/from_scratch.html)) or via an existing [public instance](https://join-lemmy.org/instances).
- No privacy policy to linkt to here, since each instance maintains their own terms, privacy, etc. 

---

### Affiliation
None

---

### Checklist

- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
