### PR TITLE
Add DarkVPS to VPS Hosting

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2877,6 +2877,16 @@ categories:
           crypto-currencies (Bitcoin, Monero, Ethereum etc..) and don't require any personal informations. They resell from
           reputable providers.
 
+      - name: DarkVPS
+        url: https://darkvps.pro
+        icon: https://darkvps.pro/favicon.ico
+        acceptsCrypto: true
+        description: |
+          Anonymous VPS hosting based in Bulgaria with private infrastructure.
+          No logs are kept, and cryptocurrency payments are accepted for maximum anonymity.
+      
+      
+      
       notableMentions: |
         See also: [1984](https://www.1984.is) based in Iceland.
         [Shinjiru](http://shinjiru.com?a_aid=5e401db24a3a4), which offers off-shore dedicated servers.


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds DarkVPS to the VPS Hosting section. Anonymous VPS provider based in Bulgaria with no-log policy and crypto payments.

---

### Supporting Material
https://darkvps.pro

---

### Affiliation
We are the owners of DarkVPS.

---

### Checklist
- [x] I have read the Contributing guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories Contributor Covenant Code of Conduct