### PR TITLE
Adds MirrorMask to Mac OS Defences

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4311,6 +4311,16 @@ categories:
         description: |
           Kernel-level, OS-level, and client-level security for macOS. With a Firewall, Blackhole, and Privatizing Proxy for Trackers, Attackers, Malware, Adware, and Spammers; with On-Demand and On-Access Anti-Virus Scanning.
 
+      - name: MirrorMask
+        url: https://mirrormask.app
+        icon: https://mirrormask.app/favicon.ico
+        openSource: false
+        description: |
+          macOS app that reshapes your algorithmic profile across Google, YouTube,
+          Facebook and Reddit by automating realistic browsing under configurable
+          personas. Makes ad-targeting data less accurate without blocking.
+          Closed-source.
+
 
     ##########################
     ###### Anti-Malware ######


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds MirrorMask to the Mac OS Defences section. MirrorMask takes a different approach to privacy than the existing entries (firewall/hardening tools) — instead of blocking tracking, it reshapes what platforms think you're interested in by automating realistic browsing activity under configurable personas.

Regarding closed-source: MirrorMask is a paid, closed-source macOS app. This is disclosed explicitly in the YAML entry via `openSource: false`. The tool is included here because its privacy function is genuine and well-evidenced — a published 5-day controlled experiment demonstrates measurable changes to Google Ad Center interest profiles. It is not a VPN, tracker blocker, or marketing tool masquerading as privacy software.

---

### Supporting Material
- Website: https://mirrormask.app
- Proof experiment (5-day controlled study): https://nanobuilds.substack.com/p/how-fast-can-you-reshape-what-google
- Privacy policy: https://mirrormask.app/privacy.html

---

### Affiliation
I am the developer of MirrorMask.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)