### PR TITLE
Add Convert.rocks to File Converters

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5045,6 +5045,14 @@ categories:
           video. It's the industry standard multimedia framework, handling a vast range
           of formats. As a command-line tool, it guarantees that all processing is done
           locally on your machine.
+      - name: Convert.rocks
+        url: https://www.convert.rocks
+        icon: https://www.convert.rocks/assets/apple-touch-icon.png
+        description: |
+          A privacy-first online file converter that processes everything directly in
+          the browser using WebAssembly and Canvas API. No files are ever uploaded to
+          any server — all conversion happens locally on your device. Supports HEIC,
+          WebP, AVIF, and PNG image formats. No signup, no tracking, no ads.
 
   - name: Creativity
     sections:


### PR DESCRIPTION
## What is Convert.rocks?

Convert.rocks is a privacy-first online file converter where all processing happens client-side in the browser using WebAssembly and Canvas API. No files are ever uploaded to any server — zero network requests during conversion.

**Supported formats:** HEIC → JPG/PNG/WebP, WebP → JPG/PNG, AVIF → JPG, PNG → JPG

## Why it fits this list

- **100% client-side** — files never leave the user's device
- **No signup, no tracking, no ads** — no accounts, no analytics cookies
- **No file size limits** — limited only by device memory
- **Works offline** after first page load
- **Chrome extension available:** https://chromewebstore.google.com/detail/hlkifcnbooeflbhjbghkgbmjpalnfpia

Website: https://www.convert.rocks