### PR TITLE
Add VirtualSMS in Virtual Phone Numbers

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1195,6 +1195,16 @@ categories:
           accepts crypto, doesn't KYC and you can delete your logs.
         acceptsCrypto: true
 
+      - name: VirtualSMS
+        url: https://virtualsms.io
+        icon: https://virtualsms.io/favicon.svg
+        github: virtualsms-io
+        acceptsCrypto: true
+        description: |
+          SMS verification using real physical SIM cards from carriers in 100+ countries.
+          One-time activations and number rentals. No account data required, accepts
+          cryptocurrency (BTC, ETH, USDT, XMR). API available for developers.
+
     ################################
     ###### Team Collaboration ######
     ################################

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1198,12 +1198,13 @@ categories:
       - name: VirtualSMS
         url: https://virtualsms.io
         icon: https://virtualsms.io/favicon.svg
-        github: virtualsms-io
         acceptsCrypto: true
         description: |
-          SMS verification using real physical SIM cards from carriers in 100+ countries.
-          One-time activations and number rentals. No account data required, accepts
-          cryptocurrency (BTC, ETH, USDT, XMR). API available for developers.
+          SMS verification with real physical SIM cards. Catalog covers 145+ countries
+          with 60+ typically in live stock at any time. Accounts need only email.
+          Payment via BTC, USDT, ETH, LTC with no KYC. HTTP API plus Node.js, Python,
+          PHP, Ruby, and .NET SDKs. An MCP server at github.com/virtualsms-io/mcp-server
+          lets AI agents (Claude, ChatGPT) order numbers and receive SMS programmatically.
 
     ################################
     ###### Team Collaboration ######


### PR DESCRIPTION
### Type
Addition

### Changes
Adds VirtualSMS to Communication → Virtual Phone Numbers. It sits alongside SMSPool, MoneroSMS, PikaSim, and Narayana already listed in the category.

VirtualSMS provides SMS verification using real physical SIM cards (not VoIP) in 145+ supported countries, with 60+ typically in live stock at any moment. Privacy-relevant features: crypto payment with no KYC, minimal data collection (email only), physical SIMs that pass WhatsApp/Telegram/Google verification (which actively blocks VoIP numbers like Google Voice, TextNow, Twilio). Operating since 2022.

### Supporting Material
- Service: https://virtualsms.io
- GitHub org: https://github.com/virtualsms-io
- MCP server (for AI agents): https://github.com/virtualsms-io/mcp-server
- Published SDKs: npm `virtualsms-sdk`, PyPI `virtualsms`, Packagist `virtualsms/sdk`, RubyGems `virtualsms-sdk`, NuGet `VirtualSMS`
- API docs: https://virtualsms.io/docs
- llms.txt: https://virtualsms.io/llms.txt

### Affiliation
I am affiliated with VirtualSMS — I operate the service. Full transparency disclosed per the template.

### Checklist
- [x] I have read the Contributing guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories Contributor Covenant Code of Conduct
