### PR TITLE
Removes entries which are no longer beneficial to privacy

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1678,14 +1678,6 @@ categories:
           A network scanner to help you monitor and secure your WiFi network. The app is totally free,
           but to use the advanced controls, you will need a Fing Box.
 
-      - name: DPI Tunnel
-        github: nomoresat/DPITunnel-android
-        icon: https://raw.githubusercontent.com/nomoresat/DPITunnel-android/main/assets/logo.webp
-        url: https://f-droid.org/packages/ru.evgeniy.dpitunnelcli/
-        description: |
-          An application for Android that uses various techniques to bypass DPI (Deep Packet Inspection)
-          systems, which are used to block some sites (not available on Play store).
-
       - name: Blokada
         url: https://blokada.org/
         icon: https://blokada.org/favicon.png

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3316,11 +3316,6 @@ categories:
           Secure file sync, sharing, collaboration and backup for individuals, small businesses and sole practitioners.
           Starts at $8/month for 2 TB.
 
-      - name: pCloud
-        url: https://www.pcloud.com
-        description: |
-          Secure and simple to use cloud storage, with cross-platform client apps. £3.99/month for 500 GB.
-
       - name: Peergos
         url: https://peergos.org/
         description: |

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4817,14 +4817,6 @@ categories:
         url: https://d.tube
         tosdrId: 2798
 
-      - name: BitChute
-        description: |
-          Established in 2017, BitChute is a video hosting service that offers a platform for
-          uploaders to evade the content restrictions found on other sites like YouTube.
-        url: https://www.bitchute.com
-        icon: https://i.ibb.co/gvxXK0Z/bitchute.png
-        tosdrId: 513
-
       wordOfWarning: |
         Without moderation, some of these platforms accommodate video creators
         whose content may not be appropriate for all audiences

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -75,16 +75,6 @@ categories:
           It omits the need for you to ever need to store or sync your passwords. They
           have apps for all the common platforms and a CLI, but you can also self-host it.
 
-      - name: Padloc
-        url: https://padloc.app
-        github: padloc/padloc
-        androidApp: app.padloc
-        iosApp: https://apps.apple.com/us/app/padloc/id1478877043
-        description: |
-          A modern, open source password manager for individuals and teams. Beautiful,
-          intuitive and dead simple to use. Apps available for all platforms and you can
-          self-host it as well.
-
       - name: ProtonPass
         url: https://proton.me/pass
         openSource: true

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4538,13 +4538,6 @@ categories:
         followWith: Bitcoin
         github: sparrowwallet/sparrow
 
-      - name: Atomic Wallet
-        url: https://atomicwallet.io/
-        description: |
-          Atomic is an open-source desktop and mobile-based wallet, where your private keys are stored on your local device, and do not touch the internet. Atomic has a great feature set, and supports swapping, staking, and lending directly from the app. However, most of Atomic's features require an active internet connection, and Atomic does not support hardware wallets yet. Therefore, it may only be a good choice as a secondary wallet, for storing small amounts of your actively used currency.
-        followWith: All Coins
-        github: Atomicwallet/bip38
-
       - name: CryptoSteel
         url: https://cryptosteel.com/how-it-works
         description: |

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1628,17 +1628,6 @@ categories:
           also a great utility to stop certain apps from collecting data and tracking your actions
           while running in the background. See on [F-Droid](https://f-droid.org/en/packages/superfreeze.tool.android)
 
-      - name: Haven
-        url: https://guardianproject.github.io/haven/
-        icon: https://play-lh.googleusercontent.com/PdE-P3oTwa6fFKqQrSuYS1S7Aa_bIq-GECLhj8kvTzXdSc6S_hUtW2hUx0aCP-3h0pQ=w240-h480
-        github: guardianproject/haven
-        androidApp: org.havenapp.main
-        tosdrId: 682
-        description: |
-          Allows you to protect yourself, your personal space and your possessions - without
-          compromising on security. Leveraging device sensors to monitor nearby space, Haven was
-          developed by The Guardian Project, in partnership with Edward Snowden.
-
       - name: Secure Task
         url: https://play.google.com/store/apps/details?id=com.balda.securetask
         icon: https://play-lh.googleusercontent.com/Xb_KbjGC3J8xrj1QmZqYhUq1A6aww5ikFuXfCqJonww-vz38y6xUjHzvH65AGrQU9P4=s48

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4769,13 +4769,6 @@ categories:
         url: https://github.com/nostr-protocol/nostr
         github: https://github.com/nostr-protocol
 
-      - name: Minds
-        description: |
-          A social media platform designed to foster open conversations and community
-          engagement. Rewards content creation.
-        url: https://www.minds.com
-        github: minds/minds
-
       - name: Lemmy
         url: https://join-lemmy.org
         github: LemmyNet/lemmy

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4161,12 +4161,6 @@ categories:
         description: |
           Internet traffic control and monitoring tool.
 
-      - name: Sticky-Keys-Slayer
-        url: https://github.com/linuz/Sticky-Keys-Slayer
-        github: linuz/Sticky-Keys-Slayer
-        description: |
-          Scans for accessibility tools backdoors via RDP.
-
       - name: SigCheck
         url: https://docs.microsoft.com/en-us/sysinternals/downloads/sigcheck
         description: |
@@ -4211,17 +4205,6 @@ categories:
         url: https://schiffer.tech/camwings.html
         description: |
           Blocks unauthorized webcam access.
-
-      - name: SpyDish
-        url: https://github.com/mirinsoft/spydish
-        github: mirinsoft/spydish
-        description: |
-          Open source GUI app built upon PowerShell, allowing you to perform a quick and easy privacy check, on Windows 10 systems.
-
-      - name: PrivaZer
-        url: https://privazer.com/
-        description: |
-          Good alternative to CCleaner, for deleting unnecessary data - logs, cache, history, etc.
 
       wordOfWarning: |
         (The above software was last tested on 01/05/20).

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4289,14 +4289,6 @@ categories:
         description: |
           Easily configure macOS security settings from the terminal.
 
-      - name: Fortress
-        url: https://github.com/essandess/macOS-Fortress
-        followWith: Mac OS
-        github: essandess/macOS-Fortress
-        description: |
-          Kernel-level, OS-level, and client-level security for macOS. With a Firewall, Blackhole, and Privatizing Proxy for Trackers, Attackers, Malware, Adware, and Spammers; with On-Demand and On-Access Anti-Virus Scanning.
-
-
     ##########################
     ###### Anti-Malware ######
     ##########################

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4615,14 +4615,6 @@ categories:
           per month) with no fees, apps and support is good. There is a premium plan
           for $10/month, with 1% cashback and 36 cards/month.
 
-      - name: Revolut Premium
-        url: https://www.revolut.com/
-        tosdrId: 2310
-        description: |
-          Revolut is more of a digital bank account, and identity checks are required
-          to sign up. Virtual cards are only available on Premium/ Metal accounts, which
-          start at $7/month.
-
       - name: MySudo
         url: https://mysudo.com
         tosdrId: 1352

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2570,15 +2570,6 @@ categories:
           A shell script application to manage ad-blocking, Dnsmasq logging, Entware and pixelserv-tls installations
           and more on supported routers running Asuswrt-Merlin firmware, including its forks.
 
-      - name: BlockParty
-        url: https://github.com/krishkumar/BlockParty
-        icon: https://user-images.githubusercontent.com/425580/202258429-28da1274-2fb6-49dc-930c-3833f929b65e.png
-        github: krishkumar/BlockParty
-        followWith: iOS/ MacOS
-        description: |
-          Native Apple (Swift) apps, for system-wide ad-blocking. Can be customized with custom host lists,
-          primarily aimed for just ad-blocking.
-
       - name: hBlock
         url: https://hblock.molinero.dev
         icon: https://raw.githubusercontent.com/hectorm/hblock/master/resources/logo/bitmaps/logo-shield-ffffff-h512.png


### PR DESCRIPTION
### Type
Removal

---

### Changes
- Removed Padloc from password managers
- Removes Atomic Wallet from Crypto Wallets
- Removes pCloud from Cloud Storage
- Removes Revolut from virtual credit cards
- Removes BitChute from video platforms
- Removes Minds from social networks
- Removes macOS-Fortress from MacOS defences
- Removes DPI Tunnel from Android Defences
- Removes Haven from Android defences
- Removes BlockParty from iOS defences, project dead
- Removes SpyDish from Windows defences
- Removes Privatezilla from Windows defences
- Removes Sticky-Keys-Slayer from Windows defences

---

### Supporting Material
Reasoning behind each removal is in the commit for each.

---

### Affiliation
None.

---

### Checklist

- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

