### PR TITLE
Adds Nextcloud Calendar to Calendars

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3095,6 +3095,15 @@ categories:
           Supports ICS (not encrypted), colours, recurring events, mail integration,
           notifications and multiple time zones.
 
+      - name: Nextcloud Calendar
+        url: https://apps.nextcloud.com/apps/calendar
+        github: nextcloud/calendar
+        openSource: true
+        icon: https://raw.githubusercontent.com/nextcloud/calendar/refs/heads/main/img/favicon.png
+        description: |
+          Calendar app for the self-hosted Nextcloud platform. Uses CalDAV for
+          sync across devices. No E2E encryption support.
+
     ###############################
     ###### Task Management ######
     ##############################

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3098,7 +3098,7 @@ categories:
       - name: Nextcloud Calendar
         url: https://apps.nextcloud.com/apps/calendar
         github: nextcloud/calendar
-        openSource: true
+        followWith: Self-Hosted
         icon: https://raw.githubusercontent.com/nextcloud/calendar/refs/heads/main/img/favicon.png
         description: |
           Calendar app for the self-hosted Nextcloud platform. Uses CalDAV for


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds NextCloud calendar to the calendars section

---

### Supporting Material

- https://apps.nextcloud.com/apps/calendar
- https://nextcloud.com/security/
- https://hackerone.com/nextcloud
- No third-party audit published

---

### Affiliation
None

---

### Checklist

- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

