### PR TITLE
Adds Koofr to Cloud Storage

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3321,6 +3321,13 @@ categories:
           Zero knowledge end-to-end encrypted affordable cloud storage made in Germany. Open-source mobile and desktop apps.
           10GB FREE with paid plans starting at €0.92/month for 100GB.
 
+      - name: Koofr
+        url: https://koofr.eu
+        description: |
+          GDPR compliant storage (web/desktop/mobile/WebDAV/RClone) with a sensible privacy policy.
+          Has optional open-source client-side encryption, compatible with RClone. Can connect to other cloud services
+          and MS Office. 10GB free, on ISO27001 servers (DE).
+
       notableMentions: |
         An alternative option, is to use a cloud computing provider, and implement
         the syncing functionality yourself, and encrypt data locally before


### PR DESCRIPTION
### Type
Addition

### Changes
Adds [Koofr](https://koofr.eu) to Cloud Storage.

### Supporting Material
Instead of a proprietary client-side encryption solution, Koofr has chosen to implement RClone's crypt, including an open-source web/mobile client (Vault). I think this is a much more sensible way to offer client-side (or "E2E") encryption, because it doesn't require any trust in the service itself and offers more versatile applications via RClone.

As said, the Vault mobile apps and web app are open source, client-side everything can be done via RClone (it has a separate `koofr` storage type) or the open WebDAV standard.

The desktop/mobile sync client/Android sync are not open-source.

https://koofr.eu/privacy-matters/
https://koofr.eu/privacy/
https://vault.koofr.net/

### Affiliation
None

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

