### PR TITLE
Add DarkVPS to Cloud Hosting

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2839,6 +2839,14 @@ categories:
           crypto-currencies (Bitcoin, Monero, Ethereum etc..) and don't require any personal informations. They resell from
           reputable providers.
 
+      - name: DarkVPS
+        url: https://darkvps.pro
+        icon: https://darkvps.pro/favicon.ico
+        acceptsCrypto: true
+        description: |
+          Anonymous & Offshore VPS Provider from Bulgaria with own private
+          infrastructure. Accepting BTC, ETH, LTC, XMR and more. 
+
       notableMentions: |
         See also: [1984](https://www.1984.is) based in Iceland.
         [Shinjiru](http://shinjiru.com?a_aid=5e401db24a3a4), which offers off-shore dedicated servers.


### PR DESCRIPTION
### Type
Addition

---
### Changes
Adds DarkVPS to Cloud Hosting section. Anonymous offshore VPS from Bulgaria,
accepts crypto, no personal info required.

---
### Supporting Material
- Website: https://darkvps.pro

---
### Affiliation
I am the owner of DarkVPS.

---
### Checklist
- [x] I have read the Contributing guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories Contributor Covenant Code of Conduct