### PR TITLE
Remove DivestOS from Mobile Operating Systems

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3846,16 +3846,6 @@ categories:
           Plus, proactive security recommendations and automatic updates take the guesswork out of keeping your personal data personal. Also currently
           only supports Pixel devices and Xiaomi Mi A2 with Fairphone 4, OnePlus 8T, OnePlus 9 test builds available. Developed by the Calyx Foundation.
 
-      - name: DivestOS
-        url: https://divestos.org
-        icon: https://divestos.org/images/favicon.png
-        github: Divested-Mobile/DivestOS-Build
-        tosdrId: 2550
-        description: |
-          DivestOS is a vastly diverged unofficial more secure and private soft fork of LineageOS. DivestOS primary goal is prolonging the life-span of
-          discontinued devices, enhancing user privacy, and providing a modest increase of security where/when possible. Project is developed and maintained
-          solely by Tad (SkewedZeppelin) since 2014.
-
       - name: LineageOS
         url: https://www.lineageos.org
         icon: https://www.lineageos.org/images/logo.png


### PR DESCRIPTION
### Type
<!-- Delete as appropriate. This is used to auto-apply labels. -->
Removal

### Changes
DivestOS has not been discontinued (see #306).

### Supporting Material
https://divested.dev/pages/blog-2024-12-23-ending_divestos

### Affiliation
None

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

