### PR TITLE
Adds Voidly Messenger to Encrypted Messaging

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -649,6 +649,17 @@ categories:
           to integrates with existing 3rd party IDs to authenticate and discover users, as
           well as to build apps on top of it.
 
+      - name: Voidly Messenger
+        url: https://msg.voidly.ai
+        icon: https://msg.voidly.ai/icon-192.png
+        openSource: true
+        github: voidly-ai/voidly-messenger
+        description: |
+          Browser-based E2E encrypted messaging PWA (no install). Signal Protocol
+          (Double Ratchet + X3DH) with ML-KEM-768 post-quantum hybrid key exchange,
+          deniable auth, sealed sender, padding and a metadata-stripping relay. All
+          crypto is client-side. Smaller user base and no third-party audit yet.
+
       notableMentions:
         - name: Chat Secure
           url: https://chatsecure.org


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds Voidly Messenger to the *Communication > Encrypted Messaging* section in `awesome-privacy.yml`.

Voidly Messenger is a browser-based E2E encrypted messaging PWA — no install required — with a modern cryptographic stack:

- **Signal Protocol**: Double Ratchet + X3DH (forward secrecy + async key agreement)
- **Post-quantum**: ML-KEM-768 + X25519 hybrid key exchange (NIST FIPS 203, harvest-now-decrypt-later resistant)
- **Deniable authentication**: HMAC-SHA256 with shared DH secret (plausible deniability — unlike Signal's Ed25519 signatures)
- **Sealed sender**: `from` address encrypted from the relay
- **Message padding**: fixed-size blocks defeat traffic analysis
- **Metadata-stripping relay**: `from_did`, `thread`, `type` stripped before store; relay never sees plaintext
- **Federation**: cross-relay routing with TOFU key pinning
- **Offline queueing**: messages delivered when recipient comes online
- **Client-side crypto only**: private keys never leave the browser

---

### Supporting Material

- Live: https://msg.voidly.ai
- Source: https://github.com/voidly-ai (organisation)
- SDK: `@voidly/agent-sdk` on npm (powers the messenger)
- Protocol spec: https://msg.voidly.ai (in-app), mirrors https://voidly.ai/agents
- Honest disclosure: smaller user base than Signal/Matrix, and no third-party security audit has been published yet.

---

### Affiliation

Yes — I am affiliated with Voidly (core contributor). Disclosing per the contributing guidelines.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)