### PR TITLE
Removes AFFiNE from Notes

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3024,16 +3024,6 @@ categories:
           community, and a lot of plugins and themes. Generally privacy-respecting, but no
           encryption out of the box, and some of the code is obfuscated or not fully open source
 
-      - name: AFFiNE
-        url: https://affine.pro
-        github: toeverything/AFFiNE
-        followWith: Windows, MacOS, Linux
-        securityAudited: false
-        subreddit: AFFiNE
-        description: |
-          Privacy first, open-source alternative to Notion, monday.com and Miro.
-          It is a knowledge management tool that allows you to create, organize and share your knowledge.
-
       - name: Cryptee
         url: https://crypt.ee/
         openSource: false


### PR DESCRIPTION
### Type
Removal

---

### Changes
AFFiNE no longer meets privacy, nor awesomeness requirements.

Re: #92

---

### Supporting Material

Privacy issues:
- 🔴 AI cannot be disabled, maintainers keep ignoring ([#7511](https://github.com/toeverything/AFFiNE/issues/7511))
- 🔴 Privacy policy reserves the right to share user data with third parties for "business purposes"
- 🟠 VC-backed by Sinovation Ventures (Kai-Fu Lee) and Redpoint China
- 🔴 Telemetry on by default in self-hosted instances (sent to `telemetry.affine.run` Mixpanel)
- 🔴 And the telemetry toggle is broken/ignored ([#12465](https://github.com/toeverything/AFFiNE/issues/12465))
- 🔴 And and telemetry payload includes unnecisary amount of PPI
  - Incl: user email, username, avatar, device UUID, current URL, OS, browser fingerprint
- 🔴 Maintainers show great disregard for this, claiming telemetry is "anonymous", even when this is provably false ([#6160](https://github.com/toeverything/AFFiNE/discussions/6160))
- 🔴 Anonymous viewers of public shared workspaces can't opt-out either, get tracked every 5 seconds ([#12821](https://github.com/toeverything/AFFiNE/issues/12821))
- 🔴 Public instance tracking is opt-out is per-browser, not per-account
- 🔴 Marketing site loaded with third-party trackers and analytics too

Security issues:
- 🔴 AI features are poorly implemented, and leak document context to remote LLM providers ([#6920](https://github.com/toeverything/AFFiNE/issues/6920))
- 🔴 No security policy, nor security.txt, no docs about reporting vulnerabilities
- 🟠 No end-to-end encryption, promised "by end of year" since 2023 ([#5491](https://github.com/toeverything/AFFiNE/issues/5491), [#5296](https://github.com/toeverything/AFFiNE/discussions/5296))
- 🟠 Architecture makes security issues likley and severe
  - Electron desktop app's `shell.openExternal` and custom URL handler accept untrusted input
  - AFFiNE docs support arbitrary web page embeds as iframes, expanding XSS/clickjacking/SSRF surface inside trusted workspaces
  - [GHSA-67vm-2mcj-8965](https://github.com/toeverything/AFFiNE/security/advisories/GHSA-67vm-2mcj-8965) - One-click RCE in v0.25.1 via crafted `affine://` URL, victim only has to click a link or visit a page that redirects to it (Mar 2026)
  - [GHSA-wx9m-v7wq-g289](https://github.com/toeverything/AFFiNE/security/advisories/GHSA-wx9m-v7wq-g289) - Open Redirect in `/redirect-proxy` via regex bypas, enables credential phishing using AFFiNE's domain reputation (Mar 2026)

Self-hosted version not well maintained:
- 🔴 Repeated data loss bugs ([#5932](https://github.com/toeverything/AFFiNE/issues/5932), [#7148](https://github.com/toeverything/AFFiNE/issues/7148), [#14191](https://github.com/toeverything/AFFiNE/issues/14191))
- 🔴 Demo workspace exposed publicly on every self-hosted instance, no way to disable, even with sign-up disabled ([#8716](https://github.com/toeverything/AFFiNE/issues/8716))
- 🔴 GraphQL API and admin panel exposed on port 3010 with no extra hardening, rate limiting, or IP restriction by default
- 🔴 Public sign-up is enabled by default on self-hosted instances ([#6141](https://github.com/toeverything/AFFiNE/issues/6141))
- 🟠 Inconsistent docker tags. E.g. `stable` tag without semver labels can deploy unintended versions ([#5975](https://github.com/toeverything/AFFiNE/discussions/5975))
- 🟠 Storage cap (100GB) and file cap (100MB) enforced in code on user's own hardware
- 🟠 README claims "feature-rich, unrestricted" self-host but it is in fact very limited ([#6641](https://github.com/toeverything/AFFiNE/issues/6641))
- 🟠 Missing features from self-hosted (like imageProxy and link-preview ([#5975](https://github.com/toeverything/AFFiNE/discussions/5975))
- 🟠 Can't remove the AFFiNE Cloud branding ([#7097](https://github.com/toeverything/AFFiNE/issues/7097))
- 🟠 To use all features on self-hosted, license validation needs to phone home to AFFiNE
- 🟠 Sign-up flow pushes Google/Microsoft/Apple SSO heavily, with no native non-cloud alternatives ([#7104](https://github.com/toeverything/AFFiNE/discussions/7104))
- 🟠 Ships with the default Cloudflare CAPTCHA secret key baked in ([#5975](https://github.com/toeverything/AFFiNE/discussions/5975))
- 🟠 Admin password reset fundamentally insecure design (see [admin docs](https://docs.affine.pro/self-host-affine/administer/user-management))
- 🟠 Default authentication for non-OIDC users is magic-link via email only unless the user actively sets a password







---

### Affiliation
None

---

### Checklist

- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

