### PR TITLE
Adds Bunker to Cloud Hosting

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2839,6 +2839,16 @@ categories:
           crypto-currencies (Bitcoin, Monero, Ethereum etc..) and don't require any personal informations. They resell from
           reputable providers.
 
+      - name: France Nuage
+        url: https://france-nuage.fr
+        github: France-Nuage/plateforme
+        openSource: true
+        icon: https://france-nuage.fr/assets/images/logo-with-name.svg
+        description: |
+          Sovereign open-source cloud platform (SSPL-1.0) hosted entirely in France. Offers managed
+          hosting of open-source apps (Grafana, Matomo, Vaultwarden, etc.) and S3-compatible object
+          storage. RGPD-native, ISO 27001 compliant, with no vendor lock-in.
+
       notableMentions: |
         See also: [1984](https://www.1984.is) based in Iceland.
         [Shinjiru](http://shinjiru.com?a_aid=5e401db24a3a4), which offers off-shore dedicated servers.

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2843,7 +2843,7 @@ categories:
         url: https://getbunker.net
         github: France-Nuage/plateforme
         openSource: true
-        icon: https://avatars.githubusercontent.com/u/189650203?v=4
+        icon: https://getbunker.net/images/en/svg/logo.svg
         description: |
           Sovereign open-source cloud platform (SSPL-1.0) hosted entirely in France. Offers managed
           hosting of open-source apps (Grafana, Matomo, Vaultwarden, etc.) and S3-compatible object

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2839,15 +2839,15 @@ categories:
           crypto-currencies (Bitcoin, Monero, Ethereum etc..) and don't require any personal informations. They resell from
           reputable providers.
 
-      - name: France Nuage
-        url: https://france-nuage.fr
+      - name: Bunker
+        url: https://getbunker.net
         github: France-Nuage/plateforme
         openSource: true
         icon: https://avatars.githubusercontent.com/u/189650203?v=4
         description: |
           Sovereign open-source cloud platform (SSPL-1.0) hosted entirely in France. Offers managed
           hosting of open-source apps (Grafana, Matomo, Vaultwarden, etc.) and S3-compatible object
-          storage. RGPD-native, ISO 27001 compliant, with no vendor lock-in.
+          storage. GDPR-native, ISO 27001 compliant, with no vendor lock-in.
 
       notableMentions: |
         See also: [1984](https://www.1984.is) based in Iceland.

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2843,7 +2843,7 @@ categories:
         url: https://france-nuage.fr
         github: France-Nuage/plateforme
         openSource: true
-        icon: https://france-nuage.fr/assets/images/logo-with-name.svg
+        icon: https://avatars.githubusercontent.com/u/189650203?v=4
         description: |
           Sovereign open-source cloud platform (SSPL-1.0) hosted entirely in France. Offers managed
           hosting of open-source apps (Grafana, Matomo, Vaultwarden, etc.) and S3-compatible object


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds [Bunker](https://getbunker.net) to the Cloud Hosting section. Bunker is a sovereign open-source cloud platform hosted entirely in France, offering managed hosting of open-source applications and S3-compatible object storage.

---

### Supporting Material

- Website: https://getbunker.net
- GitHub repo: https://github.com/France-Nuage/plateforme
- License: SSPL-1.0 (open source)
- Compliance: GDPR-native, ISO 27001, SOC 2
- Managed apps include: Grafana, Matomo, Odoo, Metabase, Vaultwarden, DocuSeal

---

### Affiliation

I am the founder of Bunker.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)