### PR TITLE
Add Maskmail in Mail Forwarding

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1035,6 +1035,15 @@ categories:
           If you already have ProtonMail's Professional (€8/month) or Visionary (€30/month) package,
           then an implementation of this feature is available via the Catch-All Email feature.
 
+      - name: Maskmail
+        url: https://maskmail.io
+        icon: https://maskmail.io/favicon/apple-touch-icon.png
+        openSource: false
+        description: |
+          Privacy-first email mask service. Create a unique mask per signup, forward what matters
+          to your real inbox, and disable any abused mask instantly. Supports custom domains,
+          anonymous replies, and a browser extension. Hosted only (closed source).
+
     ##################################
     ###### Mail Security Tools ######
     #################################


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds [Maskmail](https://maskmail.io) to **Communication > Mail Forwarding** in `awesome-privacy.yml`. Entry placed at the bottom of the section per the contributing guide.

Maskmail is a hosted email mask service. Users create a unique mask per signup, forward what matters to their real inbox, and can disable any abused mask instantly. Supports custom domains, anonymous replies, and a browser extension. Description length is within the 50-250 character range.

---

### Supporting Material
- Website: https://maskmail.io
- Privacy policy: https://maskmail.io/legal/privacy
- Terms: https://maskmail.io/legal/terms

---

### Affiliation
I work on Maskmail. Disclosing per the contributing guide.

The entry is marked `openSource: false` since the codebase is closed source (similar to the existing `33Mail` entry in the same section). Happy to move it to **Notable Mentions** if you prefer the strict open-source-only listing.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)