### PR TITLE
Add rosec in Password Managers

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -139,6 +139,30 @@ categories:
           is not fully open source, but they do regularly publish results of their
           independent [security audits](https://support.1password.com/security-assessments),
           and they have a solid reputation for transparently disclosing and fixing vulnerabilities
+      - name: rosec
+        url: https://github.com/jmylchreest/rosec
+        github: jmylchreest/rosec
+        openSource: true
+        description: >
+          A multi-provider replacement for GNOME Keyring's
+          `org.freedesktop.secrets` daemon on Linux. Any application that uses
+          `libsecret`, `secret-tool`, or speaks the Secret Service API directly
+          reads secrets from your configured providers transparently — no
+          application changes required. Built-in providers cover a local
+          encrypted vault, [Bitwarden](https://bitwarden.com) Password Manager
+          and Secrets Manager, KeePassXC `.kdbx` files (experimental), and
+          read-only access to [GNOME Keyring](https://wiki.gnome.org/Projects/GnomeKeyring)
+          for migration. Today rosec focuses on reading secrets from those
+          stores; write-back into third-party providers is on the roadmap.
+          Beyond the Secret Service API, rosec ships a built-in SSH agent that
+          auto-registers keys from any provider (no manual `ssh-add`); a FUSE
+          filesystem exposing each item's public key plus an auto-generated
+          `~/.ssh/config` snippet so existing SSH tooling works unchanged;
+          TOTP codes as live FUSE files (`cat` the file for the current
+          6-digit code — handy for shell scripts and CLI MFA flows); PAM
+          unlock-on-login; and XDG Portal support so sandboxed (Flatpak / Snap)
+          apps get per-app secrets. Non-built-in providers run as sandboxed
+          Extism WASM plugins.
       furtherInfo: >
         **Other Open Source PM**: [Buttercup](https://buttercup.pw), [Clipperz](https://clipperz.is),
         [Pass](https://www.passwordstore.org), [Padloc](https://padloc.app), [TeamPass](https://teampass.net),

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -140,29 +140,16 @@ categories:
           independent [security audits](https://support.1password.com/security-assessments),
           and they have a solid reputation for transparently disclosing and fixing vulnerabilities
       - name: rosec
-        url: https://github.com/jmylchreest/rosec
-        github: jmylchreest/rosec
-        openSource: true
+        url: https://jmylchreest.github.io/rosec/
         description: >
-          A multi-provider replacement for GNOME Keyring's
-          `org.freedesktop.secrets` daemon on Linux. Any application that uses
-          `libsecret`, `secret-tool`, or speaks the Secret Service API directly
-          reads secrets from your configured providers transparently — no
-          application changes required. Built-in providers cover a local
-          encrypted vault, [Bitwarden](https://bitwarden.com) Password Manager
-          and Secrets Manager, KeePassXC `.kdbx` files (experimental), and
-          read-only access to [GNOME Keyring](https://wiki.gnome.org/Projects/GnomeKeyring)
-          for migration. Today rosec focuses on reading secrets from those
-          stores; write-back into third-party providers is on the roadmap.
-          Beyond the Secret Service API, rosec ships a built-in SSH agent that
-          auto-registers keys from any provider (no manual `ssh-add`); a FUSE
-          filesystem exposing each item's public key plus an auto-generated
-          `~/.ssh/config` snippet so existing SSH tooling works unchanged;
-          TOTP codes as live FUSE files (`cat` the file for the current
-          6-digit code — handy for shell scripts and CLI MFA flows); PAM
-          unlock-on-login; and XDG Portal support so sandboxed (Flatpak / Snap)
-          apps get per-app secrets. Non-built-in providers run as sandboxed
-          Extism WASM plugins.
+          A backend daemon implementing the Linux Secret Service API
+          (`org.freedesktop.secrets`), with pluggable providers for a local
+          encrypted vault, [Bitwarden](https://bitwarden.com), and KeePassXC
+          `.kdbx` files. Any `libsecret` / `secret-tool` consumer (browsers,
+          `git-credential-libsecret`, etc.) reads transparently from your
+          configured providers. Bundles an SSH agent, FUSE-exposed TOTP
+          codes, and PAM unlock. Pre-1.0; write-back to third-party providers
+          is on the roadmap. Open source ([MIT](https://github.com/jmylchreest/rosec)).
       furtherInfo: >
         **Other Open Source PM**: [Buttercup](https://buttercup.pw), [Clipperz](https://clipperz.is),
         [Pass](https://www.passwordstore.org), [Padloc](https://padloc.app), [TeamPass](https://teampass.net),


### PR DESCRIPTION
### Type
Addition

### Changes
Adds rosec to `notableMentions` under Essentials → Password Managers.

rosec is a Linux Secret Service API (`org.freedesktop.secrets`) backend daemon — a drop-in replacement for GNOME Keyring's secrets daemon, with pluggable providers (local vault, Bitwarden, KeePassXC). It fits this section because privacy-aware Linux users picking a password-manager strategy nearly always pick a Secret Service backend too, and the existing `furtherInfo` already namechecks GNOME Keyring, KDE Wallet, and Seahorse for that reason. rosec is a viable alternative without requiring the rest of the GNOME / KDE desktop stack.

Filed under `notableMentions` (not `services`) because it's a backend rather than a primary user-facing PM, and because rosec is pre-1.0 — matching the "exceptions go in notable mentions, with drawbacks listed alongside" guidance in CONTRIBUTING.md.

### Supporting Material
- Repo: https://github.com/jmylchreest/rosec
- Docs: https://jmylchreest.github.io/rosec/
- License: MIT
- Packaging: AUR (`rosec`, `rosec-bin`, `rosec-git`)
- Latest release: v0.0.27 (pre-1.0; first commit 2026-02-24)

### Affiliation
I am the author and maintainer of rosec. Disclosing per CONTRIBUTING.md.

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
