### PR TITLE
Add A/SIDE — Signal Protocol encrypted private social network

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4715,6 +4715,14 @@ categories:
         should be able to choose with whom you share what, and that is what the
         following sites aim to do.
       services:
+      - name: A/SIDE
+        url: https://a-side.social
+        openSource: false
+        description: >-
+          Invitation-only private social network with end-to-end encryption using the
+          Signal Protocol. Strictly chronological feed — no algorithm, no ads, and no
+          AI training on user content. iOS and Android.
+    
       - name: Discourse
         description: |
           A fully open-source, self-hostable discussion platform usable as a mailing list,


### PR DESCRIPTION
<!--
Thank you for contributing to Awesome-Privacy! 🙌
Before submitting, please read .github/CONTRIBUTING.md, 
And ensure that your pull request follows the guidelines.
-->

### Type

Addition

---

### Changes
Adding A/SIDE to the Social Networks section. A/SIDE is an invitation-only private social network with end-to-end encryption using the Signal Protocol, a strictly chronological feed, no algorithm, no ads, and no AI training on user content. iOS and Android.

---

### Supporting Material
- Website: https://a-side.social
- Privacy policy: https://a-side.social/privacy
- Terms of service: https://a-side.social/terms

---

### Affiliation
I am the developer and founder of A/SIDE.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

