### PR TITLE
Remove CalyxOS from Mobile Opperating Systems

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3848,16 +3848,6 @@ categories:
           GrapheneOS is an open source privacy and security focused mobile OS with Android app compatibility. Developed by Daniel Micay.
           GrapheneOS is a young project, and currently only supports Pixel devices, partially due to their strong hardware security.
 
-      - name: CalyxOS
-        url: https://calyxos.org
-        icon: https://calyxos.org/assets/images/favicon/apple-touch-icon.png
-        github: CalyxOS/calyxos
-        tosdrId: 2558
-        description: |
-          CalyxOS is an free and open source Android mobile operating system that puts privacy and security into the hands of everyday users.
-          Plus, proactive security recommendations and automatic updates take the guesswork out of keeping your personal data personal. Also currently
-          only supports Pixel devices and Xiaomi Mi A2 with Fairphone 4, OnePlus 8T, OnePlus 9 test builds available. Developed by the Calyx Foundation.
-
       - name: LineageOS
         url: https://www.lineageos.org
         icon: https://www.lineageos.org/images/logo.png


### PR DESCRIPTION
### Type

Removal

---

### Changes

Re: #532
Removes CalyxOS since the project is paused (as of 01 Aug 2025) with no active releases at the moment.
Devs to appear to be actively working on it, and I plan on re-adding if/when it's resurrected.

---

### Supporting Material

Letter published and recent updates: https://calyxos.org/news/2025/08/01/a-letter-to-our-community/

Edit: The most recent update (04 May 2026) does say that test builds are now live:
https://calyxos.org/news/2026/05/04/calyxos-progress-update-4/

But still no time-frames announced.

---

### Affiliation
None

---

### Checklist

- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

