### PR TITLE
Fix icons for SimpleX and XMPP

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -610,7 +610,7 @@ categories:
         tosdrId: 7638
         iosApp: https://apps.apple.com/us/app/simplex-chat-secure-messenger/id1605771084
         androidApp: chat.simplex.app
-        icon: https://github.com/simplex-chat/simplex-chat/blob/stable/media-logos/simplex-symbol-light.png
+        icon: https://simplex.chat/img/new/logo-symbol-light.svg
         subreddit: SimpleXChat
         description: |
           Simplex is gaining popularity as a secure and private messaging app renowned
@@ -622,7 +622,7 @@ categories:
 
       - name: XMPP
         url: https://xmpp.org
-        icon: https://xmpp.org/favicon.ico
+        icon: https://xmpp.org/apple-touch-icon.png
         openSource: true
         github: xsf/xmpp.org
         description: |


### PR DESCRIPTION
### Type
Website Update

### Changes
- The SimpleX icon couldn't be fetched using the GitHub URL provided, so it defaulted to the low-res website favicon.ico.
- The XMPP resource was a low-res icon.

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

