### PR TITLE
Adds ConvertUnlimited to Metadata Removal

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3719,6 +3719,15 @@ categories:
         description: |
           Native MacOS app, with drag 'n drop image optimization and meta data removal.
 
+      - name: ConvertUnlimited
+        url: https://convertunlimited.com
+        github: dunkin-novice/convertunlimited.com
+        icon: https://www.convertunlimited.com/favicon.svg
+        description: |
+          Privacy-first browser-native file conversion and metadata removal tools. Files are processed entirely locally
+          using your browser's APIs (Canvas, WASM), meaning nothing is ever uploaded to a server.
+
+
       notableMentions: |
         It's possible (but slower) to do this without a third-party tool.
         For Windows, right click on a file, and go to: `Properties --> Details --> Remove Properties --> Remove from this File --> Select All --> OK`.


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds ConvertUnlimited, a browser-native local-first file utility suite. It enables batch file conversion and metadata removal without uploading data to any server, using client-side APIs (Canvas and WebAssembly).

---

### Supporting Material
- Project: https://convertunlimited.com/
- Repo: https://github.com/dunkin-novice/convertunlimited.com

---

### Affiliation
I am the developer of this project.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)