### PR TITLE
Adds Mullvad Browser in Browsers

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -441,6 +441,16 @@ categories:
           it's slower and some sites will be blocked or broken, among other
           [trade-offs](https://github.com/Lissy93/personal-security-checklist/issues/19)
 
+      - name: Mullvad Browser
+        url: https://mullvad.net/browser
+        icon: https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/mullvad-browser.png
+        github: mullvad/mullvad-browser
+        openSource: true
+        tosdrId: 641
+        description: |
+          A Firefox-based browser maintained in collaboration between the Tor Project and Mullvad.
+          With strong anti-fingerprinting (so users look alike), no telemetry and uBlock Origin bundled
+
       notableMentions:
       - name: Cromite
         url: https://www.cromite.org/


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds Mullvad browser

---

### Supporting Material

Links:
- Mirror: https://github.com/mullvad/mullvad-browser (you need to switch branches to view code)
- Homepage: https://mullvad.net/en/browser
- Mullvad Privacy policy: https://mullvad.net/en/help/privacy-policy
- Differences between Tor v Mullvad:
  - https://support.torproject.org/mullvad-browser/faqs/what-is-difference-mullvad-browser-tor-browser/
- List of out-going connections:
  - https://support.torproject.org/mullvad-browser/faqs/does-mullvad-browser-make-outgoing-connections/

Drawbacks:
- Slightly pushes you towards Mullvad VPN, although does work with any VPN, and the Mullvad part can be disabled
- The anti-fingerprinting can break some sites. Similar issue to LibreWolf and other implementations
- Small update lag (~2 days), as rebases off Tor

---

### Affiliation
None directly, but have been a user of Mullvad's VPN

---

### Checklist

- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

