### PR TITLE
Add Koaich to Team Collaboration

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1308,6 +1308,18 @@ categories:
           Slack alternative, with native desktop, mobile and web apps and a wide variety of
           integrations.
 
+      - name: Koaich
+        url: https://koaich.com
+        github: heysteamer/workspace-exposure-scorecard
+        description: |
+          End-to-end encrypted workspace where the vendor cannot read user
+          content. Messages, documents, files, and AI all encrypted on the user's
+          device with keys the server never sees. Group rooms use MLS (IETF RFC 9420)
+          for forward secrecy and post-compromise security on member churn. Recovery
+          uses Shamir's Secret Sharing across the user's own devices; no
+          vendor-held master key, no password-recovery backdoor. Pre-launch as of
+          May 2026; the cryptographic methodology behind the workspace-exposure
+          scoring is open-source.
       notableMentions: >
         Some chat platforms allow for cross-platform group chats, voice and video
         conferencing, but without the additional collaboration features.


### PR DESCRIPTION
Adds Koaich (https://koaich.com) to the **Team Collaboration** section.

## What Koaich is

End-to-end encrypted workspace — messages, documents, files, and AI — designed so that the vendor cannot read user content. Keys are generated on each user's device and never transmitted to the server. Group rooms use the IETF Messaging Layer Security protocol (RFC 9420) for forward secrecy and post-compromise security on member churn. Recovery uses Shamir's Secret Sharing across the user's own devices — no vendor-held master key, no password-recovery backdoor.

## Why it fits Team Collaboration

The section currently covers Rocket.Chat, RetroShare, Element, IRC, and Mattermost — all of which are server-side encrypted (Rocket.Chat, Mattermost) or federated (Element). Koaich extends the section with a vendor where the cryptographic property is closer to Signal's (nacl.box for 1:1, MLS for groups, Shamir for recovery, WebAuthn for web) applied across documents and files alongside messaging.

## Honest disclosure

**Koaich is pre-launch as of May 2026.** The waitlist is open at koaich.com; iOS, Android, and web apps are in active build; downloadable desktop apps are on the roadmap.

If `awesome-privacy` prefers post-launch products only, I completely understand a close + re-submit at GA. I'm surfacing the architecture now in case it's useful as a reference even pre-launch — particularly because the scoring methodology behind the workspace-exposure analysis tool is already open-source at [heysteamer/workspace-exposure-scorecard](https://github.com/heysteamer/workspace-exposure-scorecard).

## Verifiability

The architectural claims aren't aspirational marketing — they're documented:

- [/security](https://koaich.com/security) — full architecture page with metadata-vs-content boundary table
- [/web-tier-security](https://koaich.com/web-tier-security) — browser-specific threat model + which hardenings are LIVE vs PLANNED
- [/blast-radius](https://koaich.com/blast-radius) — analysis of 10 recent public-record breaches and the shared pattern

I follow the contribution conventions: name + url + github + description, alphabetic-ish placement within the section, schema-matched. Happy to revise tone, length, or schema fields if anything needs adjustment.

Thanks for maintaining this — `awesome-privacy` is one of the canonical references in the space.