### PR TITLE
Add NumberOTP to Virtual Phone Numbers

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1225,6 +1225,15 @@ categories:
           accepts crypto, doesn't KYC and you can delete your logs.
         acceptsCrypto: true
 
+      - name: NumberOTP
+        url: https://numberotp.com
+        icon: https://numberotp.com/favicon.ico
+        description: |
+          Real non-VoIP temporary phone numbers from 150+ countries for private SMS and
+          OTP verification. Pay-as-you-go, private dedicated inbox (not shared), instant
+          delivery, auto-refund on failed activation, and a full REST API for developers.
+          Accepted by Google, WhatsApp, Telegram, Amazon and 800+ services.
+
     ################################
     ###### Team Collaboration ######
     ################################


### PR DESCRIPTION
## What is being added?

[NumberOTP](https://numberotp.com) — a virtual phone number service for private SMS/OTP verification.

## Why does it belong here?

NumberOTP fits the existing **Virtual Phone Numbers** section under Communication. It provides real non-VoIP temporary phone numbers from 150+ countries specifically for SMS/OTP verification while protecting user privacy.

Key privacy properties:
- **Private dedicated inbox** — numbers are not shared publicly (unlike free shared services)
- **Real non-VoIP SIM-backed numbers** — accepted by Google, WhatsApp, Telegram, Amazon
- **Pay-as-you-go** — no subscription required, no persistent account linkage needed
- **Auto-refund** on failed activation — no charges for failed deliveries
- **REST API** for developers building privacy-preserving verification flows

## Checklist

- [x] Entry added under the correct section (Virtual Phone Numbers)
- [x] Required fields present: `name`, `url`, `icon`, `description`
- [x] Description is accurate and concise
- [x] No README edits (auto-generated from YAML)