### PR TITLE
Removes Privacy Badger from Browser Extensions

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1321,18 +1321,6 @@ categories:
         is able to be loaded and executed while your browsing.<br>
         Before installing anything, you should read the Word of Warning section below.
       services:
-      - name: Privacy Badger
-        url: https://privacybadger.org/
-        icon: https://i.ibb.co/8Y1ds5X/privacy-badger.png
-        github: EFForg/privacybadger
-        tosdrId: 682
-        openSource: true
-        description: |
-          Blocks invisible trackers, in order to stop advertisers and other third-parties
-          from secretly tracking where you go and what pages you look at. **Download**:
-          [Chrome](https://chrome.google.com/webstore/detail/privacy-badger/pkehgijcmpdhfbdbbnkijodmdjhbjlgp) -
-          [Firefox](https://addons.mozilla.org/en-GB/firefox/addon/privacy-badger17/)
-
       - name: uBlock Origin
         url: https://ublockorigin.com
         tosdrId: 682


### PR DESCRIPTION
### Type
Removal

### Changes
Removes Privacy Badger

- Enabling it makes you easily detected, defeating the use for additional privacy
- It doesn't use heuristics by default anymore, meaning static lists from uBlock0 will basically already do whatever this extension strives to do

### Supporting Material
https://codeberg.org/librewolf/issues/issues/2045#issuecomment-2304633
https://github.com/arkenfox/user.js/wiki/4.1-Extensions#-dont-bother

### Affiliation
None

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

