### PR TITLE
Removes First Party Isolation from Browser Extensions

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1403,14 +1403,6 @@ categories:
           Exfil attacks **Download**: [Chrome](https://chrome.google.com/webstore/detail/css-exfil-protection/ibeemfhcbbikonfajhamlkdgedmekifo) -
           [Firefox](https://addons.mozilla.org/en-US/firefox/addon/css-exfil-protection/) - [Source](https://github.com/mlgualtieri/CSS-Exfil-Protection)
 
-      - name: First Party Isolation
-        url: https://github.com/mozfreddyb/webext-firstpartyisolation
-        github: mozfreddyb/webext-firstpartyisolation
-        icon: https://addons.mozilla.org/user-media/addon_icons/865/865865-64.png?modified=1520892249
-        description: |
-          Enables the First Party isolation preference (Clicking the Fishbowl icon temporarily disables it)
-          **Download**: [Firefox](https://addons.mozilla.org/en-US/firefox/addon/first-party-isolation/)
-
       - name: Privacy-Oriented Origin Policy
         url: https://claustromaniac.github.io/poop
         github: claustromaniac/poop


### PR DESCRIPTION
### Type
Removal

---

### Changes
Removes First Party Isolation.

- Codebase is last updated 6 years ago
- Users should use dFPI (which is the default)

### Supporting Material
https://blog.mozilla.org/security/2021/02/23/total-cookie-protection/

### Affiliation
None

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

