### PR TITLE
Removes HTTPZ from Browser Extensions

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1486,14 +1486,6 @@ categories:
           [Chrome](https://chrome.google.com/webstore/detail/privacyspy/ppembnadnhiknioggbglgiciihgmkmnd) -
           [Firefox](https://addons.mozilla.org/en-US/firefox/addon/privacyspy/)
 
-      - name: HTTPZ
-        url: https://github.com/claustromaniac/httpz
-        github: claustromaniac/httpz
-        icon: https://addons.mozilla.org/user-media/addon_icons/1018/1018256-64.png?modified=9b273331
-        description: |
-          Simplified HTTPS upgrades for Firefox (lightweight alternative to HTTPS-Everywhere) **Download**:
-          [Firefox](https://addons.mozilla.org/en-US/firefox/addon/httpz/)
-
       - name: Skip Redirect
         url: https://github.com/sblask/webextension-skip-redirect
         github: sblask/webextension-skip-redirect


### PR DESCRIPTION
### Type
Removal

### Changes
Removes HTTPZ.

- Firefox already has this feature internally
- Extension hasn't been updated in 7 years
- May not even work anymore: https://github.com/claustromaniac/httpz/issues/73

### Affiliation
None

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

