### PR TITLE
Removes Privacy Redirect from Browser Extensions

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1452,14 +1452,6 @@ categories:
           [Chrome](https://chrome.google.com/webstore/detail/duckduckgo-privacy-essent/bkdgflcldnnnapblkhphbgpggdiikppg?hl=en-GB) \
           [Firefox](https://addons.mozilla.org/en-GB/firefox/addon/duckduckgo-for-firefox/)
 
-      - name: Privacy Redirect
-        url: https://github.com/SimonBrazell/privacy-redirect
-        github: SimonBrazell/privacy-redirect
-        icon: https://lh3.googleusercontent.com/pC5a_u12RlaLQhJ-5Jz87rtju2s0tCksUfZHvr3JYzAaiYZJfJapmuftodT7wuAedFOHtgxR2BGh_GmKijgiK5bJyA
-        description: |
-          A simple web extension that redirects Twitter, YouTube, Instagram & Google Maps requests to privacy friendly alternatives
-          **Download**: [Firefox](https://addons.mozilla.org/en-US/firefox/addon/privacy-redirect/) - [Chrome](https://chrome.google.com/webstore/detail/privacy-redirect/pmcmeagblkinmogikoikkdjiligflglb)
-
       - name: User Agent Switcher
         url: https://add0n.com/useragent-switcher.html
         icon: https://i.ibb.co/hyb1SGK/useragent-switcher128.png


### PR DESCRIPTION
### Type
Removal / Spelling or Grammar / Website Update / Misc

### Changes
Removes Privacy Redirect.

- Project abandoned since 2024
- Repo recently archived
- Actively developed alternative: https://github.com/libredirect/browser_extension


### Affiliation
None

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

