### PR TITLE
Removes ScriptSafe from Browser Extensions

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1343,15 +1343,6 @@ categories:
           [Chrome](https://chrome.google.com/webstore/detail/ublock-origin/cjpalhdlnbpafiamejdnhcphjbkeiagm?hl=en-GB) -
           [Firefox](https://addons.mozilla.org/en-GB/firefox/addon/ublock-origin/)
 
-      - name: ScriptSafe
-        url: https://www.andryou.com/scriptsafe
-        github: andryou/scriptsafe
-        icon: https://lh3.googleusercontent.com/c5co_NoLmEt48VC_yVp0JgKcgd83yiq_CdekGaOlBBfD5WII5mjxngERgikcQd4P56uoX9epiknU5ktXadPqj2EEVsE
-        description: |
-          Allows you to block the execution of certain scripts. **Download**:
-          [Chrome](https://chromewebstore.google.com/detail/scriptsafe/oiigbmnaadbkfbmpbfijlflahbdbdgdf) -
-          [Opera](https://addons.opera.com/en/extensions/details/scriptsafe-2/)
-
       - name: Firefox Multi-Account Containers
         github: mozilla/multi-account-containers
         icon: https://addons.mozilla.org/user-media/addon_icons/782/782160-64.png


### PR DESCRIPTION
### Type
Removal

### Changes
Removes ScriptSafe.

- Project was last touched 9 years ago
- Most likely fails to work on modern browsers
- Is automatically disabled since Chrome v138 (https://github.com/andryou/scriptsafe/issues/472)

### Affiliation
None

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

