### PR TITLE
Adds LibRedirect to Browser Extensions

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1568,6 +1568,14 @@ categories:
           and other features you may expect of a full-featured translation solution in-browser. **Download**:
           [Chrome](https://chrome.google.com/webstore/detail/gbefmodhlophhakmoecijeppjblibmie) / [Firefox](https://addons.mozilla.org/addon/linguist-translator/)
 
+      - name: LibRedirect
+        url: https://libredirect.github.io
+        github: libredirect/browser_extension
+        icon: https://github.com/libredirect/browser_extension/blob/master/img/libredirect_full.svg
+        description: |
+          A browser extension that redirects popular sites to alternative privacy friendly frontends
+          **Download**: [Firefox](https://addons.mozilla.org/firefox/addon/libredirect/) - [Chrome](https://libredirect.github.io/download_chromium.html)
+
       notableMentions:
       - name: Extension source viewer
         url: https://addons.mozilla.org/en-US/firefox/addon/crxviewer


### PR DESCRIPTION
### Type
Addition

### Changes
Adds LibRedirect, an active fork of https://github.com/SimonBrazell/privacy-redirect, which should be removed (see #573).

### Supporting Material
https://libredirect.github.io

### Affiliation
None

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

