### PR TITLE
Fix LibRedirect icon

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1519,7 +1519,7 @@ categories:
       - name: LibRedirect
         url: https://libredirect.github.io
         github: libredirect/browser_extension
-        icon: https://github.com/libredirect/browser_extension/blob/master/img/libredirect_full.svg
+        icon: https://raw.githubusercontent.com/libredirect/browser_extension/refs/heads/master/src/assets/images/libredirect.svg
         description: |
           A browser extension that redirects popular sites to alternative privacy friendly frontends
           **Download**: [Firefox](https://addons.mozilla.org/firefox/addon/libredirect/) - [Chrome](https://libredirect.github.io/download_chromium.html)


### PR DESCRIPTION
### Type
Amendment

### Changes
Oops, the icon I thought I added turned out to be the entire logo (text was invisible on GitHub light theme) _and_ the link I pasted couldn't be proxied by icon.horse. All good now.

### Affiliation
None

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

