### PR TITLE
Add MyIPNow tool for IP and network analysis

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1911,6 +1911,16 @@ categories:
           description: |
             A tool from Netcraft, for analysing what any given website is running, where it's located and information about its
             host, registrar, IP and SSL certificates.
+            
+        - name: MyIPNow
+          url: https://myipnow.net
+          github: bodiana/myipnow
+          icon: https://myipnow.net/favicon.ico
+          openSource: true
+          androidApp: https://play.google.com/store/apps/details?id=net.myipnow.app
+          iosApp: https://apps.apple.com/us/app/myipnow-ip-network-tools/id6763992136
+          description: |
+            Free online toolkit for IP lookup with geolocation, DNS lookup, WHOIS, IP blacklist check, ASN lookup, subnet calculator, ping test and speed test. No account required.
 
       wordOfWarning: >
         Browsers are inherently insecure, be careful when uploading, or entering personal details.

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1917,7 +1917,7 @@ categories:
           github: bodiana/myipnow
           icon: https://myipnow.net/favicon.ico
           openSource: true
-          androidApp: https://play.google.com/store/apps/details?id=net.myipnow.app
+          androidApp: net.myipnow.app
           iosApp: https://apps.apple.com/us/app/myipnow-ip-network-tools/id6763992136
           description: |
             Free online toolkit for IP lookup with geolocation, DNS lookup, WHOIS, IP blacklist check, ASN lookup, subnet calculator, ping test and speed test. No account required.


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds MyIPNow to the Online Tools section. MyIPNow is a free open source toolkit for IP lookup with geolocation, DNS lookup, WHOIS, IP blacklist check, ASN lookup, subnet calculator, ping test and speed test. No account required, no personal data stored. Also available as Android and iOS apps.

---

### Supporting Material
- https://myipnow.net
- https://github.com/bodiana/myipnow
- https://myipnow.net/privacy-policy/
- https://chromewebstore.google.com/detail/myipnow-ip-network-tool/ekiopmobgbbdhnogkoljmnnmclmofmpj
- https://play.google.com/store/apps/details?id=net.myipnow.app
- https://apps.apple.com/us/app/myipnow-ip-network-tools/id6763992136

---

### Affiliation
I am the developer and owner of MyIPNow.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)