### PR TITLE
Adds MetadataRemove to Metadata Removal notable mentions

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3713,7 +3713,7 @@ categories:
         - Python: [Piexif](https://github.com/hMatoba/Piexif) by @hMatoba
         - Ruby: [Exif](https://github.com/tonytonyjan/exif) by @tonytonyjan
         - PHP: [Pel](https://github.com/pel/pel) by @mgeisler
-
+        For a browser-based option, [MetadataRemove](https://metadataremove.app) can strip metadata from photos, PDFs, Office documents, video, and audio files locally — no uploads required. Also includes a [file metadata privacy checklist](https://metadataremove.app/file-metadata-privacy-checklist). Note: not open source.
     ##########################
     ###### Data Erasers ######
     ##########################


### PR DESCRIPTION
## Type

Addition of a browser-based metadata removal tool to the notable mentions section.

## Changes

Added [MetadataRemove](https://metadataremove.app) to the Metadata Removal notable mentions. It is a browser-based tool that strips hidden metadata from photos (JPG, PNG, HEIC, WebP), PDFs, Office documents (DOCX, XLSX, PPTX), video (MP4, MOV, WebM), and audio (MP3). Files are processed locally in the browser — no uploads required. Also includes a [file metadata privacy checklist](https://metadataremove.app/file-metadata-privacy-checklist).

Added as a notable mention (not a main listing) because it is not open source.

## Checklist

- [x] I have searched for existing submissions and this is not a duplicate
- [x] I have read the contributing guidelines
- [x] I have added my entry to the bottom of the appropriate section
- [x] I am not editing the README directly
- [x] My entry is correctly formatted YAML
- [x] The description is 50-250 characters and objective
- [x] I have disclosed my affiliation: I am the developer of MetadataRemove