### PR TITLE
Add NoChat - private E2EE messaging without a phone number

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -682,6 +682,20 @@ categories:
           to integrates with existing 3rd party IDs to authenticate and discover users, as
           well as to build apps on top of it.
 
+      - name: NoChat
+        url: https://nochat.io
+        openSource: true
+        github: kindlyrobotics/nochat
+        iosApp: https://apps.apple.com/app/id6756893559
+        icon: https://nochat.io/favicon.ico
+        description: |
+          NoChat is a private messaging and video-calling app that requires no phone number
+          to sign up. Messages are end-to-end encrypted with P-256 ECDH + AES-256-GCM, and
+          direct messages additionally use a hybrid post-quantum key-encapsulation scheme
+          (X25519 + ML-KEM-1024). The client code is open-source (MIT), the service is free
+          with no ads, and no personal identifiers are required to create an account.
+          Note: the implementation has not yet received an independent third-party audit.
+
       notableMentions:
         - name: Chat Secure
           url: https://chatsecure.org


### PR DESCRIPTION
## What is NoChat?

[NoChat](https://nochat.io) is a free, open-source (MIT) private messaging and video-calling app that does **not require a phone number** to sign up.

## Why it qualifies

- **No phone number required**: Account creation needs only a username.
- **E2EE**: Messages encrypted client-side with P-256 ECDH + AES-256-GCM; server sees only opaque ciphertext.
- **Post-quantum DMs**: Hybrid X25519 + ML-KEM-1024 key-encapsulation deployed for direct messages.
- **Open source (MIT)**: https://github.com/kindlyrobotics/nochat
- **Free forever**: No ads, no subscription, no data selling.
- **iOS app**: https://apps.apple.com/app/id6756893559

## Honest caveats (included in the description)

- Not yet independently third-party audited.
- Double Ratchet and Sealed Sender are planned but not yet deployed.

## Change

Added one entry to the `Encrypted Messaging` section of `awesome-privacy.yml`, after the Matrix entry and before `notableMentions`. All required fields present (`name`, `url`, `description`). Validated with `make validate` — passes (368 services).

```yaml
- name: NoChat
  url: https://nochat.io
  openSource: true
  github: kindlyrobotics/nochat
  iosApp: https://apps.apple.com/app/id6756893559
  description: |
    NoChat is a private messaging and video-calling app that requires no phone number
    to sign up. Messages are end-to-end encrypted with P-256 ECDH + AES-256-GCM, and
    direct messages additionally use a hybrid post-quantum key-encapsulation scheme
    (X25519 + ML-KEM-1024). The client code is open-source (MIT), the service is free
    with no ads, and no personal identifiers are required to create an account.
    Note: the implementation has not yet received an independent third-party audit.
```