### PR TITLE
[Add] VaultKeepR in Password Managers

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -107,6 +107,20 @@ categories:
           and email addresses for every website you use. Use the cloud version, or self-host and
           deploy within minutes via Docker.
 
+      - name: VaultKeepR
+        url: https://vaultkeepr.xyz
+        icon: https://vaultkeepr.xyz/icon.svg
+        openSource: true
+        github: VaultKeepR/vaultkeepr-core
+        iosApp: https://apps.apple.com/app/vaultkeepr/id6738030829
+        description: |
+          Decentralized zero-knowledge password manager with client-side encryption
+          (XChaCha20-Poly1305 + Argon2id). Vault data is stored on IPFS with CRDT-based
+          cross-device sync. Features on-chain digital inheritance via ERC-4337 on Base L2,
+          built-in TOTP authenticator, breach monitoring (HIBP k-anonymity), Shamir Secret
+          Sharing recovery (3-of-5), and encrypted document storage. Available as browser
+          extension (Chrome, Firefox) and iOS app. Zero telemetry.
+
       notableMentions:
       - name: Password Safe
         url: https://www.pwsafe.org


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adding VaultKeepR to the Password Managers section.

VaultKeepR is a decentralized, zero-knowledge password manager. All encryption is performed client-side (XChaCha20-Poly1305 + Argon2id). Vault data is stored on IPFS rather than a central server. It features CRDT-based cross-device sync, on-chain digital inheritance (ERC-4337 on Base L2), Shamir Secret Sharing recovery, built-in TOTP, and breach monitoring via HIBP k-anonymity. Available as a browser extension (Chrome, Firefox) and iOS app. Zero telemetry.

---

### Supporting Material

- Website: https://vaultkeepr.xyz
- Source code: https://github.com/VaultKeepR/vaultkeepr-core
- iOS App: https://apps.apple.com/app/vaultkeepr/id6738030829
- Chrome Extension: https://chromewebstore.google.com/detail/vaultkeepr
- Security documentation: https://vaultkeepr.xyz/security
- 241+ automated tests across 7 packages

---

### Affiliation

Yes. I am the sole developer and maintainer of VaultKeepR.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
