### PR TITLE
Add VSCodium in IDEs

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4329,7 +4329,16 @@ categories:
 
     - name: IDEs
       alternativeTo: ['visual studio code', 'intellij idea', 'eclipse', 'pycharm', 'atom']
-      services: []
+      services:
+      - name: VSCodium
+        url: https://vscodium.com/
+        icon: https://avatars.githubusercontent.com/u/40327449?s=200&v=4
+        github: VSCodium/vscodium
+        openSource: true
+        description: |
+          Free and open source binaries of VS Code, built without Microsoft branding
+          and with community-driven defaults. Extension compatibility can differ from
+          Microsoft's official VS Code build.
 
     - name: Terminal Emulators
       alternativeTo: ['putty', 'iterm2', 'gnome terminal', 'hyper', 'powershell']


### PR DESCRIPTION
### Type

Addition

---

### Changes

Added VSCodium to the IDEs section as a privacy-respecting, open-source alternative to Visual Studio Code.

Validation: `make validate` passed locally.

---

### Supporting Material

- https://vscodium.com/
- https://github.com/VSCodium/vscodium

---

### Affiliation

I am not affiliated with VSCodium.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)