### PR TITLE
Meta: Adds support for listings to have non-github git hosts

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -130,6 +130,8 @@ classDiagram
         +description: string
         +url: string
         +github: string?
+        +codeberg: string?
+        +git: string?
         +icon: string?
         +followWith: string?
         +securityAudited: boolean?
@@ -155,26 +157,26 @@ At a high-level, the file exports an array of categories, each containing a `nam
 categories:
   - name: Essentials
     sections: []
-- name: Communication
+  - name: Communication
     sections: []
- - name: Security Tools
+  - name: Security Tools
     sections: []
 ```
 
 Each category contains a `name` an array of `sections` (like sub-categories)
 
 ```yaml
- - name: Communication
-   sections:
-   - name: Encrypted Messaging
-     services: []
-   - name: P2P Messaging
-     intro: ...
-     services: []
-   - name: Encrypted Email
-     services: []
-   - name: Email Clients
-     services: []
+  - name: Communication
+    sections:
+      - name: Encrypted Messaging
+        services: []
+      - name: P2P Messaging
+        intro: ...
+        services: []
+      - name: Encrypted Email
+        services: []
+      - name: Email Clients
+        services: []
 ```
 
 And within each section, we find a list of `services`, each containing a listing. For example:
@@ -213,6 +215,9 @@ Each service (aka an app/website/software) has the following fields:
 | `url`             | The fully qualified domain name of the listing's homepage                                                    | `string` | Required |
 | `icon`            | A path to an icon file for the listing's logo. Must be square, no less than 64x64 and no larger than 512x512 pixels | `string` | Required |
 | `github`          | The GitHub repository hosting the listing's source code. In the format of `[owner]/[repo]`                   | `string` | Optional |
+| `codeberg`        | The Codeberg repository hosting the listing's source code. In the format of `[owner]/[repo]`                 | `string` | Optional |
+| `git`             | Full URL to the listing's source repository on any other git host (GitLab, Gitea, self-hosted, etc.)         | `string` | Optional |
+| `followWith`      | Short text shown in parentheses after the listing's name, e.g. its platform, if not cross-platform           | `string` | Optional |
 | `securityAudited` | Has the listing been audited by an accredited security researcher, with the report publicly published?       | `bool`   | Optional |
 | `acceptsCrypto`   | If payment is required/accepted, do they accept anonymous payments using cryptocurrency, such as Monero?     | `bool`   | Optional |
 | `openSource`      | Is the source code in its entirety published somewhere accessible so it can be built-from-source or self-hosted? | `bool`   | Optional |
@@ -266,9 +271,11 @@ Below is the full list of checks - it's basically the same as what is listed in 
 	- 🟡 **Duplicate name** - Service name must not already exist
 	- 🟡 **Duplicate URL** - Service URL must not already exist
 	- 🟡 **Description length** - Should be 50–250 characters
-	- 🟡 **Open source + GitHub** - If marked open source, must include `github` field
+	- 🟡 **Open source + repo** - If marked open source, must include a `github`, `codeberg` or `git` field
 - **Project Health**
 	- 🟡 **Links reachable** - Service URL and icon must not return 404
+	- 🟡 **Repo exists** - The linked GitHub repository must not return a 404
+	- 🟡 **New account** - Flags PRs from very recently created GitHub accounts
 	- 🟡 **Author disclosure** - If PR author owns the repo, they should disclose it
 	- 🟡 **Not inactive** - Repo should have a push within the last 90 days
 	- 🟡 **Minimum age** - Repo should be ≥4 months old
@@ -278,13 +285,13 @@ Below is the full list of checks - it's basically the same as what is listed in 
 	- 🟡 **Not archived** - Repo must not be archived
 	- 🟡 **No security alerts** - No open critical/high Dependabot alerts
 	- 🟡 **Minimum stars** - Repo should have ≥100 stars
-	- 🟡 **Spam detection** - Flags if user opened ≥5 PRs to other awesome-* repos in 24h
+	- 🟡 **Spam detection** - Flags if the author opened ≥3 PRs to other awesome-* repos, or PRs across ≥7 distinct repos, in the last 2 days
 - **Addition Info** (fyi only, no pass/fail requirements or warnings)
-	- 🔵 **Website check** (if has `website`) - Quickly checks for basic security requirements for website
-	- 🔵 **Source check**  (if has `github`) - Brief audit of core GitHub metrics from submitted the repo
-	- 🔵 **Android check**  (if has `android`) - Lists the trackers, permissions and stats for the Android app
-	- 🔵 **iOS check**  (if has `ios`) - Shows average rating, and app stats from the Apple App Store
-	- 🔵 **Privacy Policy check**  (if has `tosdr`) - Outputs the privacy score from ToS;DR and links to policy
+	- 🔵 **Website check** (if has `url`) - Quickly checks for basic security requirements for website
+	- 🔵 **Source check**  (if has `github`) - Brief audit of core GitHub metrics from the submitted repo
+	- 🔵 **Android check**  (if has `androidApp`) - Lists the trackers, permissions and stats for the Android app
+	- 🔵 **iOS check**  (if has `iosApp`) - Shows average rating, and app stats from the Apple App Store
+	- 🔵 **Privacy Policy check**  (if has `tosdrId`) - Outputs the privacy score from ToS;DR and links to policy
  
 </details>
 

--- a/api/open-api-spec.yml
+++ b/api/open-api-spec.yml
@@ -152,6 +152,10 @@ components:
           properties:
             github:
               type: string
+            codeberg:
+              type: string
+            git:
+              type: string
             icon:
               type: string
             followWith:

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -7,6 +7,8 @@ export interface ShortService {
 
 export interface Service extends ShortService {
   github?: string;
+  codeberg?: string;
+  git?: string;
   icon?: string;
   followWith?: string;
   securityAudited?: boolean;

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -15,16 +15,22 @@
 #  - name: string (required) - The name of the service                          #
 #  - description: string (required) - A brief description of the service        #
 #  - url: string (required) - The URL of the service                            #
-#  - github: string - The GitHub repository of the service (user/repo-name)     #
 #  - icon: string - The URL of the service's icon                               #
-#  - followWith: string - Some categories need a prefix (e.g. platform)         #
+#  - github: string - The GitHub repository of the service (user/repo-name)     #
+#  - codeberg: string - ...or (if not GH) the Codeberg repo (user/repo-name)    #
+#  - git: string - ...or the full URL to the repo for an external git host      #
+#  - iosApp: string - URL to the service's iOS app on the Apple App Store       #
+#  - androidApp: string - Package ID of Android app on Google Play Store        #
+#  - tosdrId: integer - The ID of the service on ToS;DR  (find at tosdr.org)    #
 #  - securityAudited: boolean - Has the service has been publicly audited       #
 #  - openSource: boolean - Whether the service is fully open source             #
 #  - acceptsCrypto: boolean - Whether the service accepts anonymous payment     #
-#  - tosdrId: string - The ID of the service on ToS;DR  (find at tosdr.org)     #
+#  - discordInvite: string - The invite code for the service's Discord server   #
+#  - subreddit: string - The service's subreddit name (without the r/ prefix)   #
+#  - followWith: string - Some categories need a prefix (e.g. platform)         #
 #                                                                               #
 #################################################################################
-# Licensed under CC0-1.0 (C) Alicia Sykes <https://aliciasykes.com> 2019 - 2024 #
+# Licensed under CC0-1.0 (C) Alicia Sykes <https://aliciasykes.com> 2019 - 2026 #
 #################################################################################
 
 categories:

--- a/lib/awesome-privacy-readme-gen.py
+++ b/lib/awesome-privacy-readme-gen.py
@@ -5,13 +5,17 @@ formats into markdown, and inserts into README.md
 
 import os
 import re
+import sys
 import yaml
 import logging
 from urllib.parse import urlparse
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import utils
+
 # Configure Logging
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
-logging.basicConfig(level=LOG_LEVEL)
+utils.setup_logging(LOG_LEVEL)
 logger = logging.getLogger(__name__)
 
 # Determine the project root based on the script's location

--- a/lib/awesome-privacy-readme-gen.py
+++ b/lib/awesome-privacy-readme-gen.py
@@ -116,7 +116,10 @@ def makeAwesomePrivacy(data):
           # If word of warning exists, append it
           if section.get('wordOfWarning'):
             markdown += "<details>\n<summary>⚠️ <b>Word of Warning</b></summary>\n\n"
-            markdown += f"> {section.get('wordOfWarning')}\n\n"
+            word_of_warning = '\n'.join(
+              f"> {line}".rstrip() for line in section.get('wordOfWarning').strip().split('\n')
+            )
+            markdown += f"{word_of_warning}\n\n"
             markdown += "</details>\n\n"
           # If notable mentions exists, append it (either as a list or a single string)
           if section.get('notableMentions'):

--- a/lib/checks/check-additions.py
+++ b/lib/checks/check-additions.py
@@ -21,6 +21,7 @@ SCHEMA_ERRORS_PATH = "/tmp/schema-errors.json"
 MAX_SCHEMA_ERRORS_SHOWN = 10
 
 REQUIRED_FIELDS = ("name", "description", "url", "icon")
+REPO_FIELDS = ("github", "codeberg", "git")
 
 CONTRIBUTING = "https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md"
 
@@ -57,9 +58,14 @@ DESC_LENGTH_MSG = (
     f" character range. Please see our [Contributing Guidelines]({CONTRIBUTING}#description)"
 )
 OPENSOURCE_GITHUB_MSG = (
-    "You marked this service as open source but didn't include a `github` field."
-    " Please add the repository link"
+    "You marked this service as open source but didn't include a repository link."
+    " Please add a `github`, `codeberg` or `git` field"
 )
+
+
+def _has_repo(fields):
+    """Return True if a service has any source-repository field set."""
+    return any(fields.get(f) for f in REPO_FIELDS)
 
 
 def load_json(path):
@@ -140,7 +146,7 @@ def check_open_source(diff):
     """Return a finding if an added service has openSource missing or not true."""
     for svc in diff.get("services", {}).get("added", []):
         fields = svc.get("fields", {})
-        if fields.get("openSource") is not True and not fields.get("github"):
+        if fields.get("openSource") is not True and not _has_repo(fields):
             return OPENSOURCE_MSG
     return None
 
@@ -239,7 +245,7 @@ def check_opensource_github(diff):
     """Return a finding if an added service is open source but has no github field."""
     for svc in diff.get("services", {}).get("added", []):
         fields = svc.get("fields", {})
-        if fields.get("openSource") is True and not fields.get("github"):
+        if fields.get("openSource") is True and not _has_repo(fields):
             return OPENSOURCE_GITHUB_MSG
     return None
 

--- a/lib/checks/check-additions.py
+++ b/lib/checks/check-additions.py
@@ -7,11 +7,11 @@ import sys
 
 import yaml
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(levelname)s [%(filename)s] %(message)s",
-    stream=sys.stderr,
-)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import utils
+
+utils.setup_logging()
+logger = logging.getLogger(__name__)
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 DATA_PATH = os.path.join(PROJECT_ROOT, "awesome-privacy.yml")
@@ -278,51 +278,47 @@ def main():
     critical = False
     try:
         if os.environ.get("SCHEMA_OUTCOME") == "failure":
+            logger.warning("Schema validation failed upstream, surfacing schema errors")
             findings.extend(schema_findings())
 
         diff = load_json(DIFF_PATH)
         head = load_yaml_data(DATA_PATH)
 
-        if diff:
-            finding = check_single_entry(diff)
-            if finding:
-                findings.append(finding)
-
-            finding = check_required_fields(diff, head)
-            if finding:
-                findings.append({"msg": finding, "level": "error"})
-                critical = True
-
-            finding = check_position(diff, head)
-            if finding:
-                findings.append(finding)
-
-            finding = check_open_source(diff)
-            if finding:
-                findings.append(finding)
+        if not diff:
+            logger.info("No diff at %s, nothing to validate", DIFF_PATH)
+        else:
+            added = diff.get("services", {}).get("added", [])
+            modified = diff.get("services", {}).get("modified", [])
+            logger.info("Validating additions: %d added, %d modified service(s)",
+                        len(added), len(modified))
 
             name_index = build_name_index(head, diff)
             url_index = build_url_index(head, diff)
 
-            finding = check_duplicate_name(diff, name_index)
-            if finding:
-                findings.append(finding)
-
-            finding = check_duplicate_url(diff, url_index)
-            if finding:
-                findings.append(finding)
-
-            finding = check_description_length(diff)
-            if finding:
-                findings.append(finding)
-
-            finding = check_opensource_github(diff)
-            if finding:
-                findings.append(finding)
+            checks = [
+                ("single-entry", check_single_entry(diff), False),
+                ("required-fields", check_required_fields(diff, head), True),
+                ("position", check_position(diff, head), False),
+                ("open-source", check_open_source(diff), False),
+                ("duplicate-name", check_duplicate_name(diff, name_index), False),
+                ("duplicate-url", check_duplicate_url(diff, url_index), False),
+                ("description-length", check_description_length(diff), False),
+                ("opensource-repo", check_opensource_github(diff), False),
+            ]
+            for name, finding, is_error in checks:
+                if not finding:
+                    continue
+                logger.info("flagged: %s", name)
+                if is_error:
+                    findings.append({"msg": finding, "level": "error"})
+                    critical = True
+                else:
+                    findings.append(finding)
     except Exception as exc:
-        logging.error("Unhandled error in main: %s", exc, exc_info=True)
+        logger.error("Unhandled error in main: %s", exc, exc_info=True)
 
-    logging.info("Writing %d finding(s) to %s", len(findings), FINDINGS_PATH)
+    logger.info("Additions check: %d finding(s)%s, writing to %s",
+                len(findings), " (critical)" if critical else "", FINDINGS_PATH)
     with open(FINDINGS_PATH, "w") as f:
         json.dump(findings, f)
     sys.exit(1 if critical else 0)

--- a/lib/checks/check-pr-meta.py
+++ b/lib/checks/check-pr-meta.py
@@ -7,11 +7,11 @@ import re
 import subprocess
 import sys
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(levelname)s [%(filename)s] %(message)s",
-    stream=sys.stderr,
-)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import utils
+
+utils.setup_logging()
+logger = logging.getLogger(__name__)
 
 FINDINGS_PATH = "/tmp/findings-compliance.json"
 
@@ -135,7 +135,7 @@ def check_bot_coauthors(base_ref):
         if _BOT_AUTHOR_RE.search(result.stdout):
             return BOT_MSG
     except Exception as exc:
-        logging.warning("check_bot_coauthors error: %s", exc)
+        logger.warning("check_bot_coauthors error: %s", exc)
     return None
 
 
@@ -161,6 +161,8 @@ def main():
         draft = os.environ.get("PR_DRAFT", "false")
         readme_failed = os.environ.get("README_FAILED", "false")
         base_ref = os.environ.get("BASE_REF", "")
+
+        logger.info("Checking PR metadata: title, draft, template, checkboxes, type, bot authors")
 
         finding = check_bot_coauthors(base_ref)
         if finding:
@@ -195,9 +197,10 @@ def main():
         if finding:
             findings.append({"msg": finding, "level": "error"})
     except Exception as exc:
-        logging.error("Unhandled error in main: %s", exc, exc_info=True)
+        logger.error("Unhandled error in main: %s", exc, exc_info=True)
 
-    logging.info("Writing %d finding(s) to %s", len(findings), FINDINGS_PATH)
+    logger.info("PR metadata: %d finding(s)%s, writing to %s",
+                len(findings), " (critical)" if critical else "", FINDINGS_PATH)
     write_findings(findings)
     sys.exit(1 if critical else 0)
 

--- a/lib/checks/check-project.py
+++ b/lib/checks/check-project.py
@@ -93,6 +93,10 @@ DUPLICATE_URL_MSG = (
     "The URL for this submission already exists in another listing."
     " Please check that this is not a duplicate entry"
 )
+REPO_404_MSG = (
+    "The GitHub repository linked in this submission returns a 404."
+    " Please ensure the repo exists and is publicly accessible"
+)
 
 
 def load_diff(path):
@@ -291,6 +295,21 @@ def _pr_discloses_authorship(pr_body):
     return bool(pr_body and _DISCLOSURE_RE.search(pr_body))
 
 
+def check_repo_exists(diff, token):
+    """Return REPO_404_MSG if an added service's GitHub repo returns a 404."""
+    if not token:
+        return None
+    seen = set()
+    for svc in get_services(diff, "added"):
+        owner, repo = utils.parse_github_field(svc.get("fields", {}).get("github"))
+        if not owner or (owner, repo) in seen:
+            continue
+        seen.add((owner, repo))
+        if utils.repo_status(owner, repo, token, session=SESSION) == 404:
+            return {"msg": REPO_404_MSG, "level": "error"}
+    return None
+
+
 def check_repo_signals(diff, pr_user, token, pr_body=""):
     """Check GitHub repo author match, stars, and activity for added services."""
     findings = []
@@ -393,6 +412,10 @@ def main():
             findings.append(finding)
 
         finding = check_duplicate_urls(diff, head)
+        if finding:
+            findings.append(finding)
+
+        finding = check_repo_exists(diff, token)
         if finding:
             findings.append(finding)
 

--- a/lib/checks/check-project.py
+++ b/lib/checks/check-project.py
@@ -12,11 +12,8 @@ import yaml
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import utils
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(levelname)s [%(filename)s] %(message)s",
-    stream=sys.stderr,
-)
+utils.setup_logging()
+logger = logging.getLogger(__name__)
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 DATA_PATH = os.path.join(PROJECT_ROOT, "awesome-privacy.yml")
@@ -112,9 +109,9 @@ def check_url(url):
     """Return True if the URL is reachable. Transport errors are treated as reachable."""
     ok, status = utils.check_url(url, SESSION, TIMEOUT)
     if not ok:
-        logging.warning("URL check failed for %s (HTTP %d)", url, status)
+        logger.warning("URL check failed for %s (HTTP %d)", url, status)
     elif status is None:
-        logging.warning("URL check error for %s (unreachable)", url)
+        logger.warning("URL check error for %s (unreachable)", url)
     return ok
 
 
@@ -206,7 +203,7 @@ def check_security_alerts(owner, repo, token):
 def check_spam_prs(pr_user, token):
     """Return list of spam findings based on recent PR activity."""
     if not pr_user or not token:
-        logging.warning("check_spam_prs skipped: %s", "no PR_USER" if not pr_user else "no GITHUB_TOKEN")
+        logger.warning("check_spam_prs skipped: %s", "no PR_USER" if not pr_user else "no GITHUB_TOKEN")
         return []
     try:
         since = (datetime.now(timezone.utc) - timedelta(days=SPAM_WINDOW_DAYS)).strftime("%Y-%m-%d")
@@ -216,7 +213,7 @@ def check_spam_prs(pr_user, token):
         if not data:
             return []
         items = data.get("items", [])
-        logging.info("check_spam_prs: %d total PRs for %s (fetched %d)",
+        logger.info("check_spam_prs: %d total PRs for %s (fetched %d)",
                      data.get("total_count", 0), pr_user, len(items))
         this_repo = os.environ.get("GITHUB_REPOSITORY", "Lissy93/awesome-privacy").lower()
         awesome_count = 0
@@ -231,7 +228,7 @@ def check_spam_prs(pr_user, token):
             repo_name = repo_url.rstrip("/").split("/")[-1].lower()
             if repo_name.startswith("awesome-"):
                 awesome_count += 1
-        logging.info("check_spam_prs: %d awesome-* PRs, %d distinct repos",
+        logger.info("check_spam_prs: %d awesome-* PRs, %d distinct repos",
                      awesome_count, len(distinct_repos))
         findings = []
         if awesome_count >= SPAM_AWESOME_THRESHOLD:
@@ -240,7 +237,7 @@ def check_spam_prs(pr_user, token):
             findings.append(SPAM_MANY_MSG)
         return findings
     except Exception as exc:
-        logging.warning("check_spam_prs error for %s: %s", pr_user, exc)
+        logger.warning("check_spam_prs error for %s: %s", pr_user, exc)
         return []
 
 
@@ -389,11 +386,12 @@ def main():
     try:
         pr_user = os.environ.get("PR_USER", "")
         token = os.environ.get("GITHUB_TOKEN", "")
-        logging.info("PR_USER=%s, GITHUB_TOKEN=%s", pr_user or "(empty)", "present" if token else "MISSING")
+        logger.info("Checking project health: links, spam, account age, duplicate URLs, repo signals")
+        logger.info("PR_USER=%s, GITHUB_TOKEN=%s", pr_user or "(empty)", "present" if token else "MISSING")
 
         diff = load_diff(DIFF_PATH)
         if not diff:
-            logging.info("No diff file at %s, nothing to check", DIFF_PATH)
+            logger.info("No diff file at %s, nothing to check", DIFF_PATH)
             with open(FINDINGS_PATH, "w") as f:
                 json.dump(findings, f)
             sys.exit(0)
@@ -421,9 +419,9 @@ def main():
 
         findings.extend(check_repo_signals(diff, pr_user, token, pr_body))
     except Exception as exc:
-        logging.error("Unhandled error in main: %s", exc, exc_info=True)
+        logger.error("Unhandled error in main: %s", exc, exc_info=True)
 
-    logging.info("Writing %d finding(s) to %s", len(findings), FINDINGS_PATH)
+    logger.info("Project health: %d finding(s), writing to %s", len(findings), FINDINGS_PATH)
     with open(FINDINGS_PATH, "w") as f:
         json.dump(findings, f)
     sys.exit(0)

--- a/lib/checks/check-readme-edits.py
+++ b/lib/checks/check-readme-edits.py
@@ -4,10 +4,17 @@ The generated section is between <!-- awesome-privacy-start --> and <!-- awesome
 """
 
 import argparse
+import logging
 import os
 import re
 import subprocess
 import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import utils
+
+utils.setup_logging()
+logger = logging.getLogger(__name__)
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 README_PATH = ".github/README.md"
@@ -17,11 +24,6 @@ README_ABS = os.path.join(PROJECT_ROOT, README_PATH)
 EXIT_PASS = 0
 EXIT_FAIL = 1
 EXIT_RUNTIME_ERROR = 2
-
-# ANSI color helpers
-_use_color = sys.stderr.isatty() and not os.environ.get("NO_COLOR")
-red = (lambda s: f"\033[31m{s}\033[0m") if _use_color else (lambda s: s)
-green = (lambda s: f"\033[32m{s}\033[0m") if _use_color else (lambda s: s)
 
 
 def get_changed_files(base_ref):
@@ -77,27 +79,30 @@ def main():
     parser.add_argument("--base-ref", required=True, help="Base git ref to diff against")
     args = parser.parse_args()
 
+    logger.info("Checking README for direct edits to the generated section")
+
     # Skip if README wasn't changed
     changed_files = get_changed_files(args.base_ref)
     if README_PATH not in changed_files:
-        print(green("README not modified, skipping."))
+        logger.info("README not modified, skipping")
         sys.exit(EXIT_PASS)
 
     # Find marker lines
     start_line, end_line = get_marker_lines()
     if start_line is None or end_line is None:
-        print("Could not find generated-section markers in README, skipping check.")
+        logger.warning("Generated-section markers not found in README, skipping check")
         sys.exit(EXIT_PASS)
 
     # Check if any changed lines fall within the generated section
     changed_lines = get_changed_line_numbers(args.base_ref)
+    logger.info("README edited (%d line(s)); generated section spans lines %d-%d",
+                len(changed_lines), start_line, end_line)
     for line_num in changed_lines:
         if start_line <= line_num <= end_line:
-            print(red("Direct edits to the generated section of the README are not allowed."), file=sys.stderr)
-            print(red("Edit awesome-privacy.yml instead and the README will be regenerated."), file=sys.stderr)
+            logger.error("Edit to generated section at line %d: edit awesome-privacy.yml instead", line_num)
             sys.exit(EXIT_FAIL)
 
-    print(green("README changes are outside the generated section, OK."))
+    logger.info("README edits are outside the generated section, OK")
     sys.exit(EXIT_PASS)
 
 

--- a/lib/checks/check-review-ready.py
+++ b/lib/checks/check-review-ready.py
@@ -12,7 +12,15 @@ Writes:
 """
 
 import json
+import logging
 import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import utils
+
+utils.setup_logging()
+logger = logging.getLogger(__name__)
 
 WORK_DIR = "pr-meta"
 MAINTAINER = "Lissy93"
@@ -67,22 +75,28 @@ def write_action(action):
 
 
 def main():
+    logger.info("Checking whether the PR is ready for maintainer review")
     if already_notified():
+        logger.info("Maintainer already notified, action=skip")
         write_action("skip")
         return
 
     reviews = read_json("reviews.json")
     approvals = count_external_approvals(reviews)
+    logger.info("%d external approval(s), need %d", approvals, REQUIRED_APPROVALS)
 
     if approvals < REQUIRED_APPROVALS:
+        logger.info("Not enough approvals, action=skip")
         write_action("skip")
         return
 
     check_runs = read_json("check-runs.json")
     if not all_checks_passing(check_runs):
+        logger.info("Not all %d check run(s) passing, action=skip", len(check_runs))
         write_action("skip")
         return
 
+    logger.info("Approvals met and all checks passing, action=notify")
     write_action("notify")
 
 

--- a/lib/checks/check-yaml-diff.py
+++ b/lib/checks/check-yaml-diff.py
@@ -4,13 +4,18 @@ Enforces the single-entry rule and outputs a JSON diff to /tmp/pr-diff.json.
 
 import argparse
 import json
+import logging
 import os
 import sys
 
 import yaml
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import utils
 from yaml_diff import build_index, diff_index, load_yaml_at_ref
+
+utils.setup_logging()
+logger = logging.getLogger(__name__)
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 DATA_PATH = os.path.join(PROJECT_ROOT, "awesome-privacy.yml")
@@ -21,17 +26,12 @@ EXIT_PASS = 0
 EXIT_RULE_VIOLATION = 1
 EXIT_RUNTIME_ERROR = 2
 
-_use_color = sys.stderr.isatty() and not os.environ.get("NO_COLOR")
-red = (lambda s: f"\033[31m{s}\033[0m") if _use_color else (lambda s: s)
-green = (lambda s: f"\033[32m{s}\033[0m") if _use_color else (lambda s: s)
-yellow = (lambda s: f"\033[33m{s}\033[0m") if _use_color else (lambda s: s)
-
 
 def load_base_yaml(base_ref):
     """Load the YAML from the base ref using git show."""
     data = load_yaml_at_ref(base_ref, PROJECT_ROOT)
     if data is None:
-        print(yellow("awesome-privacy.yml not found in base ref, treating as empty"), file=sys.stderr)
+        logger.warning("awesome-privacy.yml not found in base ref, treating as empty")
         return {"categories": []}
     return data
 
@@ -42,7 +42,7 @@ def load_head_yaml():
         with open(DATA_PATH) as f:
             return yaml.safe_load(f)
     except (FileNotFoundError, yaml.YAMLError) as e:
-        print(red(f"Failed to load head YAML: {e}"), file=sys.stderr)
+        logger.error("Failed to load head YAML: %s", e)
         sys.exit(EXIT_RUNTIME_ERROR)
 
 
@@ -125,6 +125,7 @@ def main():
     parser.add_argument("--base-ref", required=True)
     args = parser.parse_args()
 
+    logger.info("Diffing awesome-privacy.yml against base ref %s", args.base_ref)
     base = load_base_yaml(args.base_ref)
     head = load_head_yaml()
 
@@ -176,24 +177,26 @@ def main():
     write_github_output("has_service_changes", str(bool(added or removed or modified)).lower())
     write_diff_summary(diff_result)
 
+    logger.info("Diff: services +%d/-%d/~%d, sections %d, categories %d, duplicates %d",
+                len(added), len(removed), len(modified), len(sections), len(categories), len(dup_entries))
+
     added_count = len(added)
     if added_count > 1:
-        print(red(f"Single-entry rule violation: {added_count} service additions found."), file=sys.stderr)
+        logger.error("Single-entry rule violation: %d service additions found", added_count)
         sys.exit(EXIT_RULE_VIOLATION)
     added_sections = [s for s in sections if s["change_type"] == "added_section"]
     if added_count == 0 and len(added_sections) > 1:
-        print(red(f"Single-entry rule violation: {len(added_sections)} section additions found."), file=sys.stderr)
+        logger.error("Single-entry rule violation: %d section additions found", len(added_sections))
         sys.exit(EXIT_RULE_VIOLATION)
 
     if duplicates:
         names = ", ".join(f"{d[2]} (in {d[0]} → {d[1]})" for d in duplicates)
-        print(red(f"Duplicate service names found: {names}"), file=sys.stderr)
+        logger.error("Duplicate service names found: %s", names)
         sys.exit(EXIT_RULE_VIOLATION)
 
     total = len(added) + len(removed) + len(modified)
-    print(green(f"Single-entry rule passed. {total} service "
-                f"({added_count} added), {len(sections)} section, "
-                f"{len(categories)} category change(s)."))
+    logger.info("Single-entry rule passed: %d service change(s) (%d added), %d section, %d category change(s)",
+                total, added_count, len(sections), len(categories))
     sys.exit(EXIT_PASS)
 
 

--- a/lib/checks/detect-changes.py
+++ b/lib/checks/detect-changes.py
@@ -4,9 +4,16 @@ Sets GitHub Actions output: yaml_changed.
 """
 
 import argparse
+import logging
 import os
 import subprocess
 import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import utils
+
+utils.setup_logging()
+logger = logging.getLogger(__name__)
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -33,13 +40,13 @@ def main():
 
     changed_files = [f for f in result.stdout.strip().splitlines() if f]
 
-    print("Changed files:")
+    logger.info("Detected %d changed file(s) since %s", len(changed_files), args.base_ref)
     for f in changed_files:
-        print(f"  {f}")
+        logger.debug("  %s", f)
 
     yaml_changed = YAML_FILE in changed_files
     write_github_output("yaml_changed", str(yaml_changed).lower())
-    print(f"yaml_changed={yaml_changed}")
+    logger.info("%s changed: %s", YAML_FILE, yaml_changed)
 
 
 if __name__ == "__main__":

--- a/lib/checks/format-comment.py
+++ b/lib/checks/format-comment.py
@@ -6,11 +6,11 @@ import os
 import sys
 from datetime import datetime, timezone
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(levelname)s [%(filename)s] %(message)s",
-    stream=sys.stderr,
-)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import utils
+
+utils.setup_logging()
+logger = logging.getLogger(__name__)
 
 ARTIFACTS_DIR = "/tmp/artifacts"
 OUTPUT_DIR = "/tmp/pr-meta"
@@ -220,8 +220,10 @@ def main():
             with open(os.path.join(OUTPUT_DIR, "run-id.txt"), "w") as f:
                 f.write(run_id)
 
+        logger.info("Aggregating findings from all check jobs in %s", ARTIFACTS_DIR)
         errors, warnings = collect_findings()
         all_findings = errors + warnings
+        logger.info("Collected %d error(s) and %d warning(s)", len(errors), len(warnings))
         with open(os.path.join(OUTPUT_DIR, "findings-count.txt"), "w") as f:
             f.write(str(len(all_findings)))
         with open(os.path.join(OUTPUT_DIR, "error-count.txt"), "w") as f:
@@ -233,10 +235,12 @@ def main():
                            repo_stats)
 
         comment = format_comment(all_findings, user, changes_summary, run_id, repo_stats)
-        with open(os.path.join(OUTPUT_DIR, "comment.md"), "w") as f:
+        comment_path = os.path.join(OUTPUT_DIR, "comment.md")
+        with open(comment_path, "w") as f:
             f.write(comment)
+        logger.info("Wrote PR comment to %s", comment_path)
     except Exception as exc:
-        logging.error("Unhandled error in main: %s", exc, exc_info=True)
+        logger.error("Unhandled error in main: %s", exc, exc_info=True)
 
     sys.exit(0)
 

--- a/lib/checks/make-info-stats.py
+++ b/lib/checks/make-info-stats.py
@@ -20,6 +20,7 @@ Excuse the code, it's a bit scrappy! But it's never used in the prod app.
 
 import argparse
 import json
+import logging
 import os
 import sys
 from datetime import datetime, timezone
@@ -27,6 +28,9 @@ from urllib.parse import urlparse
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import utils
+
+utils.setup_logging()
+logger = logging.getLogger(__name__)
 
 DIFF_PATH = "/tmp/pr-diff.json"
 OUTPUT_PATH = "/tmp/repo-stats.md"
@@ -54,7 +58,7 @@ def _api_get(url, params=None, timeout=TIMEOUT, headers=None):
         if resp.status_code == 200:
             return resp.json()
     except Exception as e:
-        print(f"Fetch failed for {url}: {e}", file=sys.stderr)
+        logger.warning("Fetch failed for %s: %s", url, e)
     return None
 
 
@@ -494,7 +498,7 @@ def _resolve_args(argv):
         if args.repo:
             owner, repo = utils.parse_github_field(args.repo)
             if not owner:
-                print(f"Invalid repo format: {args.repo}", file=sys.stderr)
+                logger.error("Invalid repo format: %s", args.repo)
                 sys.exit(1)
             result["owner"], result["repo"] = owner, repo
         return [result]
@@ -504,7 +508,7 @@ def _resolve_args(argv):
         with open(DIFF_PATH) as f:
             diff = json.load(f)
     except Exception:
-        print("No arguments and no diff file found", file=sys.stderr)
+        logger.info("No arguments and no diff file found, nothing to look up")
         sys.exit(0)
 
     field_map = {"github": "owner", "url": "url", "androidApp": "android",
@@ -524,9 +528,10 @@ def _resolve_args(argv):
             services.append(result)
 
     if not services:
-        print("No checkable fields found in diff", file=sys.stderr)
+        logger.info("No checkable fields found in diff")
         sys.exit(0)
 
+    logger.info("Found %d service(s) with checkable fields in diff", len(services))
     return services
 
 
@@ -535,19 +540,21 @@ def _build_service_sections(args, token):
     sections = []
 
     if args["owner"] and args["repo"]:
+        logger.info("Fetching repo stats for %s/%s", args["owner"], args["repo"])
         data = fetch_all_data(args["owner"], args["repo"], token)
         if data:
             sections.append(("Repo Stats", format_markdown(grade_stats(data))))
         else:
-            print(f"Failed to fetch repo data for {args['owner']}/{args['repo']}", file=sys.stderr)
+            logger.warning("Failed to fetch repo data for %s/%s", args["owner"], args["repo"])
 
     if args["url"]:
         parsed_url = urlparse(args["url"])
         if parsed_url.hostname and parsed_url.hostname.rstrip(".").endswith("github.com"):
-            print(f"Skipped website checks, since github repo was specified: {args['url']}", file=sys.stderr)
+            logger.info("Skipped website checks, github repo was specified: %s", args["url"])
             sections.append(("Website Checks",
                              f"- {ORANGE} **Skipped** web checks, since repo URL was submitted instead of a website"))
         else:
+            logger.info("Fetching website checks for %s", args["url"])
             site_data = fetch_website_data(args["url"])
             has_sec_txt = check_security_txt(args["url"])
             if site_data or has_sec_txt is not None:
@@ -555,25 +562,28 @@ def _build_service_sections(args, token):
                                  format_markdown(grade_website_stats(site_data, args["url"], has_sec_txt))))
 
     if args["android"]:
+        logger.info("Fetching Android app info for %s", args["android"])
         data = fetch_android_data(args["android"])
         if data:
             sections.append(("Android App", format_markdown(grade_android_stats(data))))
         else:
-            print(f"Failed to fetch Android data for {args['android']}", file=sys.stderr)
+            logger.warning("Failed to fetch Android data for %s", args["android"])
 
     if args["ios"]:
+        logger.info("Fetching iOS app info for %s", args["ios"])
         data = fetch_ios_data(args["ios"])
         if data:
             sections.append(("iOS App", format_markdown(grade_ios_stats(data))))
         else:
-            print(f"Failed to fetch iOS data for {args['ios']}", file=sys.stderr)
+            logger.warning("Failed to fetch iOS data for %s", args["ios"])
 
     if args["tosdr"]:
+        logger.info("Fetching ToS;DR privacy policy for %s", args["tosdr"])
         data = fetch_tosdr_data(args["tosdr"])
         if data:
             sections.append(("Privacy Policy", format_markdown(grade_tosdr_stats(data))))
         else:
-            print(f"Failed to fetch ToS;DR data for {args['tosdr']}", file=sys.stderr)
+            logger.warning("Failed to fetch ToS;DR data for %s", args["tosdr"])
 
     return sections
 
@@ -587,6 +597,8 @@ def main():
         all_md_parts = []
 
         for svc_args in all_services:
+            if svc_args.get("name"):
+                logger.info("Looking up submission info for %s", svc_args["name"])
             sections = _build_service_sections(svc_args, token)
             if not sections:
                 continue
@@ -609,9 +621,9 @@ def main():
         else:
             with open(OUTPUT_PATH, "w") as f:
                 f.write(md + "\n")
-            print(f"Stats written to {OUTPUT_PATH}")
+            logger.info("Submission stats written to %s", OUTPUT_PATH)
     except Exception as e:
-        print(f"make-info-stats failed: {e}", file=sys.stderr)
+        logger.error("make-info-stats failed: %s", e, exc_info=True)
 
     sys.exit(0)
 

--- a/lib/checks/prepare-comment.py
+++ b/lib/checks/prepare-comment.py
@@ -10,8 +10,16 @@ Writes:
   pr-meta/final-comment.md    — the body to post or update with
 """
 
+import logging
 import os
 import re
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import utils
+
+utils.setup_logging()
+logger = logging.getLogger(__name__)
 
 WORK_DIR = "pr-meta"
 
@@ -160,11 +168,13 @@ def write_output(action, body=""):
 
 
 def main():
+    logger.info("Preparing PR bot comment (deciding create/update/skip)")
     check_run_id = os.environ.get("CHECK_RUN_ID", "")
     repo = os.environ.get("GITHUB_REPOSITORY", "")
 
     new_body = read_file(os.path.join(WORK_DIR, "comment.md"))
     if not new_body:
+        logger.info("No new comment.md to post, action=skip")
         write_output("skip")
         return
 
@@ -172,15 +182,18 @@ def main():
 
     # No existing comment — create a new one
     if not existing_body:
+        logger.info("No existing bot comment, action=create")
         write_output("create", new_body)
         return
 
     # Existing comment — build an edit line to append
     if not check_run_id:
+        logger.info("Existing comment but no CHECK_RUN_ID, action=skip")
         write_output("skip")
         return
 
     findings_count = read_findings_count(new_body)
+    logger.info("Existing comment found, new run reports %d finding(s)", findings_count)
     edit_line = build_edit_line(existing_body, findings_count, check_run_id, repo)
 
     # Refresh the Submission Info block even if findings haven't changed
@@ -188,6 +201,7 @@ def main():
     info_changed = refreshed_body != existing_body
 
     if not edit_line and not info_changed:
+        logger.info("State unchanged and submission info unchanged, action=skip")
         write_output("skip")
         return
 
@@ -197,6 +211,8 @@ def main():
             updated = updated.rstrip() + "\n" + edit_line
         else:
             updated = updated.rstrip() + "\n\n---\n\n### Updates\n\n" + edit_line
+    logger.info("Updating comment (new edit=%s, submission info changed=%s), action=update",
+                bool(edit_line), info_changed)
     write_output("update", updated)
 
 

--- a/lib/generate-changelog.py
+++ b/lib/generate-changelog.py
@@ -4,6 +4,7 @@ and enriches entries with GitHub PR metadata.
 """
 
 import json
+import logging
 import os
 import re
 import subprocess
@@ -14,7 +15,11 @@ from typing import Any
 import requests
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import utils
 from yaml_diff import build_index, diff_index, load_yaml_at_ref
+
+utils.setup_logging()
+logger = logging.getLogger(__name__)
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 OUTPUT_PATH = os.path.join(PROJECT_ROOT, ".github", "changelog.json")
@@ -49,7 +54,7 @@ def get_commits():
             continue
         lines = record.split("\n", 3)
         if len(lines) != 4:
-            print(f"  Skipping malformed log record: {record[:80]}", file=sys.stderr)
+            logger.warning("Skipping malformed log record: %s", record[:80])
             continue
         sha, date, author, message = lines
         commits.append({"sha": sha, "date": date, "author": author, "message": message})
@@ -216,7 +221,7 @@ def fetch_pr_metadata(pr_numbers):
     if token:
         headers["Authorization"] = f"token {token}"
     else:
-        print("  No GITHUB_TOKEN set, API rate limit will be low", file=sys.stderr)
+        logger.warning("No GITHUB_TOKEN set, API rate limit will be low")
 
     metadata = {}
     for i, pr_num in enumerate(sorted(pr_numbers)):
@@ -234,12 +239,12 @@ def fetch_pr_metadata(pr_numbers):
                     "authorAvatar": data.get("user", {}).get("avatar_url", ""),
                 }
             elif resp.status_code == 403:
-                print(f"  Rate limited at PR #{pr_num}, stopping API calls", file=sys.stderr)
+                logger.warning("Rate limited at PR #%s, stopping API calls", pr_num)
                 break
             elif resp.status_code != 404:
-                print(f"  PR #{pr_num}: HTTP {resp.status_code}", file=sys.stderr)
+                logger.warning("PR #%s: HTTP %s", pr_num, resp.status_code)
         except requests.RequestException as e:
-            print(f"  PR #{pr_num}: {e}", file=sys.stderr)
+            logger.warning("PR #%s: %s", pr_num, e)
         if i < len(pr_numbers) - 1:
             time.sleep(0.1)
 
@@ -265,8 +270,7 @@ def fetch_rejections(headers, cached_rejections, checked_prs):
                         "per_page": 100, "page": page},
             )
             if resp.status_code != 200:
-                print(f"  Rejections page {page}: HTTP {resp.status_code} — keeping cache",
-                      file=sys.stderr)
+                logger.warning("Rejections page %s: HTTP %s, keeping cache", page, resp.status_code)
                 return cached_rejections, checked_prs
             prs = resp.json()
             if not prs:
@@ -274,7 +278,7 @@ def fetch_rejections(headers, cached_rejections, checked_prs):
 
             for pr in prs:
                 if pr.get("created_at", "") < REJECTIONS_SINCE:
-                    print(f"  Reused {reused} cached, checked {new_calls} new PR(s)")
+                    logger.info("Reused %d cached, checked %d new PR(s)", reused, new_calls)
                     return rejections, checked
                 if pr.get("merged_at"):
                     continue
@@ -316,10 +320,10 @@ def fetch_rejections(headers, cached_rejections, checked_prs):
             page += 1
             time.sleep(0.1)
         except requests.RequestException as e:
-            print(f"  Rejections: {e} — keeping cache", file=sys.stderr)
+            logger.warning("Rejections: %s, keeping cache", e)
             return cached_rejections, checked_prs
 
-    print(f"  Reused {reused} cached, checked {new_calls} new PR(s)")
+    logger.info("Reused %d cached, checked %d new PR(s)", reused, new_calls)
     return rejections, checked
 
 
@@ -342,7 +346,7 @@ def load_existing():
 
 
 def main():
-    print("Generating changelog from git history...")
+    logger.info("Generating changelog from git history")
 
     existing_entries, processed_shas, existing_rejections, checked_prs = load_existing()
     commits = get_commits()
@@ -360,7 +364,7 @@ def main():
     new_processed = set()
 
     if new_commits:
-        print(f"Processing {len(new_commits)} new commit(s) ({len(existing_entries)} existing)...")
+        logger.info("Processing %d new commit(s) (%d existing)", len(new_commits), len(existing_entries))
 
         all_shas = [c["sha"] for c in commits]
         sha_to_parent = {all_shas[i]: all_shas[i + 1] for i in range(len(all_shas) - 1)}
@@ -387,9 +391,9 @@ def main():
                 continue
 
             changes = diff_commits(c["sha"], parent)
-            prefix = f"  [{i}/{len(new_commits)}]"
+            prefix = f"[{i}/{len(new_commits)}]"
             if changes is None:
-                print(f"{prefix} {c['date'][:10]} (no data changes)", flush=True)
+                logger.debug("%s %s (no data changes)", prefix, c["date"][:10])
                 continue
 
             # Sync merges pull content in via their 2nd parent, so their own message
@@ -407,11 +411,11 @@ def main():
                             continue
                         new_processed.add(pm["sha"])
                         counts = emit(pm["sha"], pm["date"], pm["message"], pm_changes)
-                        print(f"{prefix} {pm['date'][:10]} {counts}  (via sync) {pm['message'][:50]}", flush=True)
+                        logger.debug("%s %s %s  (via sync) %s", prefix, pm["date"][:10], counts, pm["message"][:50])
                     continue
 
             counts = emit(c["sha"], c["date"], c["message"], changes)
-            print(f"{prefix} {c['date'][:10]} {counts}  {c['message'][:60]}", flush=True)
+            logger.debug("%s %s %s  %s", prefix, c["date"][:10], counts, c["message"][:60])
 
         # Enrich entries missing full avatar data
         for e in existing_entries:
@@ -420,14 +424,14 @@ def main():
                 pr_numbers_to_fetch.add(pr["number"])
 
         if pr_numbers_to_fetch:
-            print(f"Fetching metadata for {len(pr_numbers_to_fetch)} PR(s)...")
+            logger.info("Fetching metadata for %d PR(s)", len(pr_numbers_to_fetch))
             pr_meta = fetch_pr_metadata(pr_numbers_to_fetch)
             for entry in new_entries + existing_entries:
                 pr = entry.get("pr")
                 if pr and pr.get("number") and pr["number"] in pr_meta:
                     entry["pr"] = pr_meta[pr["number"]]
     else:
-        print(f"No new commits. {len(existing_entries)} entries up to date.")
+        logger.info("No new commits, %d entries up to date", len(existing_entries))
 
     all_entries = sorted(new_entries + existing_entries, key=lambda e: e["date"], reverse=True)
 
@@ -436,9 +440,9 @@ def main():
     api_headers = {"User-Agent": "awesome-privacy", "Accept": "application/vnd.github.v3+json"}
     if token:
         api_headers["Authorization"] = f"token {token}"
-    print("Fetching rejected PRs...")
+    logger.info("Fetching rejected PRs")
     rejections, checked_prs = fetch_rejections(api_headers, existing_rejections, checked_prs)
-    print(f"  Found {len(rejections)} rejection(s)")
+    logger.info("Found %d rejection(s)", len(rejections))
 
     os.makedirs(os.path.dirname(OUTPUT_PATH), exist_ok=True)
     with open(OUTPUT_PATH, "w") as f:
@@ -450,7 +454,7 @@ def main():
             "rejections": rejections,
         }, f, indent=2, ensure_ascii=False)
 
-    print(f"Wrote {len(all_entries)} entries + {len(rejections)} rejections to {OUTPUT_PATH}")
+    logger.info("Wrote %d entries + %d rejections to %s", len(all_entries), len(rejections), OUTPUT_PATH)
 
 
 if __name__ == "__main__":

--- a/lib/review-listings.py
+++ b/lib/review-listings.py
@@ -6,7 +6,7 @@ Checks:
 - https-url: homepage URL uses HTTPS
 - icon-reachable: icon URL does not 404
 - description-len: description is 50 to 280 chars (over 420 escalates to warn)
-- opensource-github: openSource listings include a github field
+- opensource-github: openSource listings include a github, codeberg or git field
 - duplicate-url: no URL appears in more than one listing
 - androidApp-valid: androidApp is a package name, not a URL
 - iosApp-reachable: App Store URL resolves
@@ -222,10 +222,14 @@ def _description_len(entry: Entry, ctx: Context) -> Iterable[Finding]:
 
 @check("opensource-github")
 def _opensource_github(entry: Entry, ctx: Context) -> Iterable[Finding]:
-    """openSource: true services must include a github field."""
-    if entry.service.get("openSource") is True and not entry.service.get("github"):
-        yield _finding(entry, "opensource-github", "warn",
-                       "marked openSource but missing `github` field")
+    """openSource: true services must include a github, codeberg or git field."""
+    svc = entry.service
+    if svc.get("openSource") is True and not (
+        svc.get("github") or svc.get("codeberg") or svc.get("git")
+    ):
+        yield _finding(entry, "opensource-github", "error",
+                       "marked openSource but missing a repository link "
+                       "(`github`, `codeberg` or `git`)")
 
 
 @check("androidApp-valid")

--- a/lib/schema.json
+++ b/lib/schema.json
@@ -32,6 +32,14 @@
                         "type": ["string", "null"],
                         "pattern": "^([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+|https://github\\.com/.+)$"
                       },
+                      "codeberg": {
+                        "type": ["string", "null"],
+                        "pattern": "^([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+|https://codeberg\\.org/.+)$"
+                      },
+                      "git": {
+                        "type": ["string", "null"],
+                        "pattern": "^https?://.+"
+                      },
                       "icon": {
                         "type": ["string", "null"],
                         "pattern": "^https?://.+"

--- a/lib/utils/__init__.py
+++ b/lib/utils/__init__.py
@@ -12,6 +12,7 @@ from .github import (
     repo_is_archived,
     repo_is_fork,
     repo_pushed_days_ago,
+    repo_status,
 )
 from .http import DEFAULT_TIMEOUT, DEFAULT_USER_AGENT, check_url, make_session
 from .term import make_colors, setup_logging
@@ -36,6 +37,7 @@ __all__ = [
     "repo_is_archived",
     "repo_is_fork",
     "repo_pushed_days_ago",
+    "repo_status",
     "setup_logging",
     "slugify",
 ]

--- a/lib/utils/__init__.py
+++ b/lib/utils/__init__.py
@@ -1,21 +1,30 @@
-"""Shared helpers for lib/ scripts. Re-exports the public API of each submodule."""
+"""Shared helpers for lib/ scripts. Re-exports the public API of each submodule.
 
-from .data import DATA_PATH, PROJECT_ROOT, iter_services, load_yaml, slugify
-from .github import (
-    AI_BOT_AUTHORS,
-    commit_has_bot,
-    fetch_repo,
-    gh_get,
-    parse_github_field,
-    repo_age_days,
-    repo_has_license,
-    repo_is_archived,
-    repo_is_fork,
-    repo_pushed_days_ago,
-    repo_status,
-)
-from .http import DEFAULT_TIMEOUT, DEFAULT_USER_AGENT, check_url, make_session
+`.term` (logging/colors) is stdlib-only and always importable. The other
+submodules need `requests`/`yaml`; some CI jobs install no extra deps, so those
+imports are skipped there, letting `setup_logging()` work without them.
+"""
+
 from .term import make_colors, setup_logging
+
+try:
+    from .data import DATA_PATH, PROJECT_ROOT, iter_services, load_yaml, slugify
+    from .github import (
+        AI_BOT_AUTHORS,
+        commit_has_bot,
+        fetch_repo,
+        gh_get,
+        parse_github_field,
+        repo_age_days,
+        repo_has_license,
+        repo_is_archived,
+        repo_is_fork,
+        repo_pushed_days_ago,
+        repo_status,
+    )
+    from .http import DEFAULT_TIMEOUT, DEFAULT_USER_AGENT, check_url, make_session
+except ImportError:
+    pass
 
 __all__ = [
     "AI_BOT_AUTHORS",

--- a/lib/utils/github.py
+++ b/lib/utils/github.py
@@ -67,6 +67,23 @@ def fetch_repo(owner, repo, token, session=None):
     return gh_get(f"/repos/{owner}/{repo}", token, session=session, label="repos")
 
 
+def repo_status(owner, repo, token, session=None, timeout=DEFAULT_TIMEOUT):
+    """Return the HTTP status code for a repo, or None on transport error."""
+    session = session or make_session()
+    headers = {"Accept": "application/vnd.github.v3+json"}
+    if token:
+        headers["Authorization"] = f"token {token}"
+    try:
+        resp = session.get(
+            f"https://api.github.com/repos/{owner}/{repo}",
+            headers=headers, timeout=timeout,
+        )
+        return resp.status_code
+    except Exception as exc:
+        logging.warning("[repo-status] request error for %s/%s: %s", owner, repo, exc)
+        return None
+
+
 def commit_has_bot(commit, bot_set):
     """Return True if a commit was authored or co-authored by a known AI bot."""
     author = commit.get("commit", {}).get("author", {})

--- a/lib/utils/term.py
+++ b/lib/utils/term.py
@@ -4,21 +4,65 @@ import logging
 import os
 import sys
 
-_COLOR_CODES = {"red": 31, "green": 32, "yellow": 33, "cyan": 36, "bold": 1, "dim": 2}
+_COLOR_CODES = {"red": 31, "green": 32, "yellow": 33, "blue": 34, "cyan": 36, "bold": 1, "dim": 2}
+
+_LEVEL_COLORS = {
+    "DEBUG": _COLOR_CODES["dim"],
+    "INFO": _COLOR_CODES["cyan"],
+    "WARNING": _COLOR_CODES["yellow"],
+    "ERROR": _COLOR_CODES["red"],
+    "CRITICAL": _COLOR_CODES["red"],
+}
+
+
+def _color_enabled(stream=None):
+    """Decide whether ANSI colors should be emitted (respects NO_COLOR, enables in CI)."""
+    if os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("FORCE_COLOR") or os.environ.get("GITHUB_ACTIONS") or os.environ.get("CI"):
+        return True
+    stream = stream or sys.stderr
+    return bool(getattr(stream, "isatty", lambda: False)())
+
+
+def _paint(text, code):
+    return f"\033[{code}m{text}\033[0m"
+
+
+class _ColorFormatter(logging.Formatter):
+    """Renders records as `LEVEL [file] message`, colored by level when enabled."""
+
+    def __init__(self, color):
+        super().__init__()
+        self.color = color
+
+    def format(self, record):
+        level = f"{record.levelname:<7}"
+        location = f"[{record.filename}]"
+        message = record.getMessage()
+        if self.color:
+            level = _paint(level, _LEVEL_COLORS.get(record.levelname, 0))
+            location = _paint(location, _COLOR_CODES["dim"])
+        text = f"{level} {location} {message}"
+        if record.exc_info:
+            text += "\n" + self.formatException(record.exc_info)
+        return text
 
 
 def setup_logging(level="INFO"):
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(_ColorFormatter(_color_enabled()))
     logging.basicConfig(
         level=getattr(logging, str(level).upper(), logging.INFO),
-        format="%(levelname)s [%(filename)s] %(message)s",
-        stream=sys.stderr,
+        handlers=[handler],
+        force=True,
     )
 
 
 def make_colors(enabled=None):
     """Return {name: callable(str) -> str}; no-ops when colors disabled."""
     if enabled is None:
-        enabled = sys.stderr.isatty() and not os.environ.get("NO_COLOR")
+        enabled = _color_enabled()
     if not enabled:
         return {name: (lambda s: s) for name in _COLOR_CODES}
     return {name: (lambda s, c=code: f"\033[{c}m{s}\033[0m") for name, code in _COLOR_CODES.items()}

--- a/lib/validate-awesome-privacy.py
+++ b/lib/validate-awesome-privacy.py
@@ -57,7 +57,9 @@ def resolve_path(data, path_parts):
 FIELD_HINTS = {
     "url": "must start with http:// or https://",
     "icon": "must start with http:// or https://",
-    "github": "must be `user/repo` or a full https://github.com/... URL",
+    "github": "must be `user/repo`",
+    "codeberg": "must be `user/repo`",
+    "git": "must be a full http(s):// URL to the source repository",
     "iosApp": "must be a full https://apps.apple.com/... URL",
     "androidApp": "must be a package name like `com.example.app`",
     "discordInvite": "must be a discord invite code or https://discord.gg/... URL",

--- a/lib/validate-awesome-privacy.py
+++ b/lib/validate-awesome-privacy.py
@@ -1,9 +1,16 @@
 import json
+import logging
 import os
 import sys
 
 import yaml
 from jsonschema import Draft7Validator
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import utils
+
+utils.setup_logging()
+logger = logging.getLogger(__name__)
 
 # Paths (relative to project root)
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -17,13 +24,6 @@ EXIT_VALIDATION_ERRORS = 1
 EXIT_RUNTIME_ERROR = 2
 
 MAX_ERRORS = 20
-
-# ANSI color helpers (disabled when NO_COLOR is set or stderr is not a TTY)
-_use_color = sys.stderr.isatty() and not os.environ.get("NO_COLOR")
-red = (lambda s: f"\033[31m{s}\033[0m") if _use_color else (lambda s: s)
-green = (lambda s: f"\033[32m{s}\033[0m") if _use_color else (lambda s: s)
-yellow = (lambda s: f"\033[33m{s}\033[0m") if _use_color else (lambda s: s)
-dim = (lambda s: f"\033[2m{s}\033[0m") if _use_color else (lambda s: s)
 
 
 def _clean(v):
@@ -139,12 +139,12 @@ def load_yaml(path):
         with open(path, "r") as f:
             return yaml.safe_load(f)
     except FileNotFoundError:
-        print(red(f"File not found: {path}"), file=sys.stderr)
+        logger.error("File not found: %s", path)
         sys.exit(EXIT_RUNTIME_ERROR)
     except yaml.YAMLError as e:
         msg = format_yaml_error(e)
         write_errors_file([msg])
-        print(red(f"Failed to parse YAML: {msg}"), file=sys.stderr)
+        logger.error("Failed to parse YAML: %s", msg)
         sys.exit(EXIT_RUNTIME_ERROR)
 
 
@@ -153,10 +153,10 @@ def load_schema(path):
         with open(path, "r") as f:
             return json.load(f)
     except FileNotFoundError:
-        print(red(f"File not found: {path}"), file=sys.stderr)
+        logger.error("File not found: %s", path)
         sys.exit(EXIT_RUNTIME_ERROR)
     except json.JSONDecodeError as e:
-        print(red(f"Failed to parse JSON schema: {e}"), file=sys.stderr)
+        logger.error("Failed to parse JSON schema: %s", e)
         sys.exit(EXIT_RUNTIME_ERROR)
 
 
@@ -171,6 +171,7 @@ def validate(data, schema):
 
 
 def main():
+    logger.info("Validating awesome-privacy.yml against schema")
     data = load_yaml(DATA_PATH)
     schema = load_schema(SCHEMA_PATH)
     errors = validate(data, schema)
@@ -179,10 +180,10 @@ def main():
         write_errors_file(errors)
         shown = errors[:MAX_ERRORS]
         for msg in shown:
-            print(red("ERROR") + " " + msg, file=sys.stderr)
+            logger.error(msg)
         if len(errors) > MAX_ERRORS:
-            print(dim(f"...and {len(errors) - MAX_ERRORS} more"), file=sys.stderr)
-        print(red(f"Validation failed: {len(errors)} error(s)"), file=sys.stderr)
+            logger.warning("...and %d more", len(errors) - MAX_ERRORS)
+        logger.error("Validation failed: %d error(s)", len(errors))
         sys.exit(EXIT_VALIDATION_ERRORS)
 
     # Gather stats
@@ -195,7 +196,8 @@ def main():
         for s in c.get("sections", [])
     )
     clear_errors_file()
-    print(green(f"Valid! {num_categories} categories, {num_sections} sections, {num_services} services"))
+    logger.info("Valid! %d categories, %d sections, %d services",
+                num_categories, num_sections, num_services)
     sys.exit(EXIT_VALID)
 
 

--- a/web/src/components/things/ChangelogTimeline.svelte
+++ b/web/src/components/things/ChangelogTimeline.svelte
@@ -611,16 +611,16 @@
       color: var(--changelog-add);
     }
     &.rem {
-      background: color-mix(in srgb, var(--changelog-rem) 33%, transparent);
-      color: var(--changelog-rem);
+      background: color-mix(in srgb, var(--changelog-rej) 33%, transparent);
+      color: var(--changelog-rej);
     }
     &.mod {
       background: color-mix(in srgb, var(--changelog-mod) 33%, transparent);
       color: var(--changelog-mod);
     }
     &.rej {
-      background: color-mix(in srgb, var(--changelog-rej) 33%, transparent);
-      color: var(--changelog-rej);
+      background: color-mix(in srgb, var(--changelog-rem) 33%, transparent);
+      color: var(--changelog-rem);
     }
   }
 

--- a/web/src/components/things/ListingHero.astro
+++ b/web/src/components/things/ListingHero.astro
@@ -1,7 +1,7 @@
 ---
 import type { Section, Service } from '../../types/Service';
 import { slugify } from '@utils/fetch-data';
-import { parseMarkdown, formatLink } from '@utils/parse-markdown';
+import { parseMarkdown, formatLink, codebergUrl } from '@utils/parse-markdown';
 import FontAwesome from '@components/form/FontAwesome.svelte';
 import SaveListing from '@components/things/SaveListing.svelte';
 import ServiceIcon from '@components/things/ServiceIcon.astro';
@@ -19,6 +19,8 @@ const {
 	description,
 	url,
 	github,
+	codeberg,
+	git,
 	tosdrId,
 	iosApp,
 	androidApp,
@@ -45,6 +47,16 @@ const infoLinks = [
 		label: 'GitHub',
 		href: `https://github.com/${github}`,
 		text: `github.com/${github}`,
+	},
+	codeberg && {
+		label: 'Codeberg',
+		href: codebergUrl(codeberg),
+		text: formatLink(codebergUrl(codeberg)),
+	},
+	git && {
+		label: 'Source',
+		href: git,
+		text: formatLink(git),
 	},
 	tosdrId && {
 		label: 'Privacy',
@@ -104,7 +116,7 @@ const highlights = [
 		cls: 'warning',
 		title: `${name} is not open source`,
 	},
-	(openSource || (github && openSource !== false)) && {
+	(openSource || ((github || codeberg || git) && openSource !== false)) && {
 		icon: 'openSource',
 		text: 'Open Source',
 		cls: 'great',

--- a/web/src/components/things/ServiceCard.astro
+++ b/web/src/components/things/ServiceCard.astro
@@ -1,5 +1,5 @@
 ---
-import { formatLink } from '@utils/parse-markdown';
+import { formatLink, codebergUrl } from '@utils/parse-markdown';
 import type { Service } from 'src/types/Service';
 import FontAwesome from '@components/form/FontAwesome.svelte';
 import SaveListing from '@components/things/SaveListing.svelte';
@@ -51,6 +51,20 @@ const { service, sectionName, categoryName } = Astro.props;
 			service.github && (
 				<a class="link" href={`https://github.com/${service.github}`}>
 					<FontAwesome iconName="sourceCode" /> GitHub
+				</a>
+			)
+		}
+		{
+			service.codeberg && (
+				<a class="link" href={codebergUrl(service.codeberg)}>
+					<FontAwesome iconName="sourceCode" /> Codeberg
+				</a>
+			)
+		}
+		{
+			service.git && (
+				<a class="link" href={service.git}>
+					<FontAwesome iconName="sourceCode" /> Source
 				</a>
 			)
 		}

--- a/web/src/components/things/ServiceCard.svelte
+++ b/web/src/components/things/ServiceCard.svelte
@@ -2,7 +2,7 @@
   import FontAwesome from '@components/form/FontAwesome.svelte';
   import SaveListing from '@components/things/SaveListing.svelte';
   import { slugify } from '@utils/fetch-data';
-  import { formatLink } from '@utils/parse-markdown';
+  import { formatLink, codebergUrl } from '@utils/parse-markdown';
   import type { Service } from 'src/types/Service';
 
   interface Props {
@@ -68,6 +68,26 @@
         rel="noopener noreferrer"
       >
         <FontAwesome iconName="sourceCode" /> GitHub
+      </a>
+    {/if}
+    {#if service.codeberg}
+      <a
+        class="link"
+        href={codebergUrl(service.codeberg)}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <FontAwesome iconName="sourceCode" /> Codeberg
+      </a>
+    {/if}
+    {#if service.git}
+      <a
+        class="link"
+        href={service.git}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <FontAwesome iconName="sourceCode" /> Source
       </a>
     {/if}
     <a href={`/${categorySlug}/${sectionSlug}/${serviceRef}`}>

--- a/web/src/components/things/ServiceList.astro
+++ b/web/src/components/things/ServiceList.astro
@@ -1,6 +1,6 @@
 ---
 import Button from '@components/form/Button.astro';
-import { parseMarkdown, formatLink } from '@utils/parse-markdown';
+import { parseMarkdown, formatLink, codebergUrl } from '@utils/parse-markdown';
 import type { Service } from 'src/types/Service';
 import FontAwesome from '@components/form/FontAwesome.svelte';
 import DeleteListing from '@components/things/DeleteListing.svelte';
@@ -111,7 +111,8 @@ const sortedServices = [...(services || [])].sort((a, b) =>
 										</span>
 									)}
 									{service.openSource ||
-									(service.github && service.openSource !== false) ? (
+									((service.github || service.codeberg || service.git) &&
+										service.openSource !== false) ? (
 										<span
 											class="meta-item great"
 											title={`${service.name} is open source`}
@@ -132,6 +133,27 @@ const sortedServices = [...(services || [])].sort((a, b) =>
 												target="_blank"
 											>
 												<FontAwesome iconName="github" /> {service.github}
+											</a>
+										</span>
+									)}
+									{service.codeberg && (
+										<span
+											class="meta-item"
+											title={`View ${service.name} on Codeberg`}
+										>
+											<a href={codebergUrl(service.codeberg)} target="_blank">
+												<FontAwesome iconName="sourceCode" />{' '}
+												{formatLink(codebergUrl(service.codeberg))}
+											</a>
+										</span>
+									)}
+									{service.git && (
+										<span
+											class="meta-item"
+											title={`View ${service.name} source code`}
+										>
+											<a href={service.git} target="_blank">
+												<FontAwesome iconName="sourceCode" /> Source
 											</a>
 										</span>
 									)}

--- a/web/src/pages/[...listing].astro
+++ b/web/src/pages/[...listing].astro
@@ -15,6 +15,7 @@ import SocialShare from '@components/form/Social.astro';
 import DataActions from '@components/things/DataActions.svelte';
 import type { AwesomePrivacy, Section, Service } from '../types/Service';
 import { fetchData, slugify } from '@utils/fetch-data';
+import { codebergUrl } from '@utils/parse-markdown';
 import { fetchChangelog } from '@utils/fetch-changelog';
 import { fetchGitHubStats } from '@utils/fetch-repo-info';
 import { fetchTosdrPrivacy } from '@utils/fetch-privacy-policy';
@@ -39,6 +40,8 @@ const {
 	description,
 	url,
 	github,
+	codeberg,
+	git,
 	tosdrId,
 	discordInvite,
 	subreddit,
@@ -235,6 +238,11 @@ const makeSoftwareSchema = () => {
 		.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
 		.replace(/[*_`~]/g, '')
 		.trim();
+	const codeRepository = github
+		? `https://github.com/${github}`
+		: codeberg
+			? codebergUrl(codeberg)
+			: git || null;
 	return {
 		'@context': 'https://schema.org',
 		'@type': 'SoftwareApplication',
@@ -245,7 +253,7 @@ const makeSoftwareSchema = () => {
 		...(operatingSystem.length && {
 			operatingSystem: operatingSystem.join(', '),
 		}),
-		...(github && { codeRepository: `https://github.com/${github}` }),
+		...(codeRepository && { codeRepository }),
 	};
 };
 ---

--- a/web/src/types/Service.ts
+++ b/web/src/types/Service.ts
@@ -9,6 +9,8 @@ export interface Service {
   description: string;
   url: string;
   github?: string;
+  codeberg?: string;
+  git?: string;
   icon?: string;
   links?: Array<{
     title: string;

--- a/web/src/utils/do-searchy-searchy.ts
+++ b/web/src/utils/do-searchy-searchy.ts
@@ -9,6 +9,8 @@ export interface SearchItem {
   name?: string;
   url?: string;
   github?: string;
+  codeberg?: string;
+  git?: string;
   logo?: string;
 }
 
@@ -42,6 +44,8 @@ export const prepareSearchItems = (categories: Category[]): SearchItem[] => {
           description: service.description,
           url: service.url,
           github: service.github || '',
+          codeberg: service.codeberg || '',
+          git: service.git || '',
           category: category.name,
           sectionName: section.name,
           logo: service.icon || '',
@@ -61,6 +65,8 @@ export const searchOptions = {
     { name: 'notableMentions', weight: 0.5 },
     { name: 'alternativeTo', weight: 0.5 },
     { name: 'github', weight: 0.4 },
+    { name: 'codeberg', weight: 0.4 },
+    { name: 'git', weight: 0.3 },
     { name: 'url', weight: 0.2 },
     { name: 'description', weight: 0.1 },
     { name: 'intro', weight: 0.1 },

--- a/web/src/utils/parse-markdown.ts
+++ b/web/src/utils/parse-markdown.ts
@@ -44,3 +44,7 @@ export const formatLink = (link: string) => {
     .replace(/^(https?:\/\/)?(www\.)?/, '')
     .replace(/\/+$/, '');
 };
+
+// Resolve a `codeberg` field (either `owner/repo` shorthand or a full URL) to a full URL.
+export const codebergUrl = (codeberg: string) =>
+  /^https?:\/\//.test(codeberg) ? codeberg : `https://codeberg.org/${codeberg}`;


### PR DESCRIPTION
### Type
Website Update + Lib scripts

---

### Changes
- PR will show error msg if the added repo is 404 (seems basic, but non-existent/private repos keep getting submitted!)
- Adds new fields for `codeberg` and generic `git`, to support (sensible!) projects which don't use just GitHub
- Fixes markdown formatting for the warning sections (bullets were breaking out of blockquote)
- In the lib scripts, removed print statements and replaced with more grepable logs
- And then updates the comment at the start of awesome-privacy.yml to reflect fields

---

### Supporting Material
N/A

---

### Affiliation
N/A

---

### Checklist

- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

