### PR TITLE
Adds Cypher eSIM to Virtual Phone Numbers

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1224,14 +1224,15 @@ categories:
           accepts crypto, doesn't KYC and you can delete your logs.
         acceptsCrypto: true
         
-      - name: Cypher eSIM
-        url: https://cypheresim.com/
-        icon: https://cypheresim.com/favicon.ico
-        description: |
-          Anonymous travel eSIM offering mobile data in 180+ countries. No KYC, no
-          account and no email are required at sign-up. Payments are accepted in USDT,
-          USDC, BTC, ETH and SOL. Requires an eSIM-compatible device.
-        acceptsCrypto: true
+        - name: Cypher eSIM
+          url: https://cypheresim.com/
+          icon: https://cypheresim.com/logo.svg
+          description: |
+            Anonymous travel eSIM offering mobile data in 180+ countries. No KYC, no
+            account and no email are required at sign-up. Payments are accepted in USDT,
+            USDC, BTC, ETH and SOL. Requires an eSIM-compatible device.
+          acceptsCrypto: true
+
 
     ################################
     ###### Team Collaboration ######

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1223,6 +1223,15 @@ categories:
           Inbound/outbound calls, SMS and roaming internet. Very private, has a Tor mirror,
           accepts crypto, doesn't KYC and you can delete your logs.
         acceptsCrypto: true
+        
+      - name: Cypher eSIM
+        url: https://cypheresim.com/
+        icon: https://cypheresim.com/favicon.ico
+        description: |
+          Anonymous travel eSIM offering mobile data in 180+ countries. No KYC, no
+          account and no email are required at sign-up. Payments are accepted in USDT,
+          USDC, BTC, ETH and SOL. Requires an eSIM-compatible device.
+        acceptsCrypto: true
 
     ################################
     ###### Team Collaboration ######


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds Cypher eSIM to the Virtual Phone Numbers section — a privacy-respecting, no-KYC travel eSIM (mobile data) for 180+ countries, paid anonymously with crypto. Consistent with the other privacy-first eSIM / number providers already listed in this section (Silent.link, PikaSim, nadanada, Narayana).

---

### Supporting Material

- Website: https://cypheresim.com/
- No KYC, no account, no email required at sign-up; no tracking / no personal data collected
- Anonymous payment in crypto: USDT, USDC, BTC, ETH, SOL
- Works on any eSIM-compatible device

**Re: open source** — like the other eSIM / mobile-data providers already listed in this same section (Silent.link, PikaSim, nadanada), Cypher eSIM is a managed mobile-connectivity service and is not open source — a consumer eSIM/carrier service cannot be self-hosted by nature. It is proposed on privacy grounds: no identity, no account, no email, no tracking, and anonymous crypto payment, which matches the list's privacy criteria. Happy to provide more detail if required.

---

### Affiliation

Yes — I am affiliated with Cypher eSIM (team member).

---

### Checklist

- [x] I have read the Contributing guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories Contributor Covenant Code of Conduct
