### PR TITLE
Add Private Terminal (Finance → Investment Research)

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4815,11 +4815,9 @@ categories:
         followWith: Desktop
         openSource: true
         description: |
-          A free, MIT-licensed, local-first desktop research dashboard for stocks, crypto
-          and macroeconomics. Watchlist with multi-indicator charts, 29 FRED macro series,
-          and cross-asset analysis tools. No accounts, no telemetry, no analytics, no cloud
-          sync — all state lives in a local SQLite database, and the only network requests
-          are to the public data sources you enable (FRED, Yahoo Finance, optional RSS).
+          Free, MIT-licensed, local-first desktop research dashboard for stocks, crypto
+          and macroeconomics. No accounts, no telemetry, no cloud sync — all data stays
+          in a local SQLite database.
 
 
   - name: Social

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4805,6 +4805,22 @@ categories:
         [Skrooge](https://skrooge.org), and
         [kMyMoney](https://kmymoney.org).
 
+    - name: Investment Research
+      alternativeTo: ['tradingview', 'koyfin', 'bloomberg terminal', 'yahoo finance']
+      services:
+      - name: Private Terminal
+        url: https://www.privateacb.com/terminal/
+        github: cerkon1/private-terminal
+        icon: https://raw.githubusercontent.com/cerkon1/private-terminal/master/src-tauri/icons/128x128.png
+        followWith: Desktop
+        openSource: true
+        description: |
+          A free, MIT-licensed, local-first desktop research dashboard for stocks, crypto
+          and macroeconomics. Watchlist with multi-indicator charts, 29 FRED macro series,
+          and cross-asset analysis tools. No accounts, no telemetry, no analytics, no cloud
+          sync — all state lives in a local SQLite database, and the only network requests
+          are to the public data sources you enable (FRED, Yahoo Finance, optional RSS).
+
 
   - name: Social
     sections:


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds [Private Terminal](https://github.com/cerkon1/private-terminal) to the Finance category, under a proposed new **Investment Research** section (alternativeTo: TradingView, Koyfin, Bloomberg Terminal, Yahoo Finance). Happy to re-home it to a different section if you'd prefer.

Private Terminal is a free, MIT-licensed, local-first desktop research dashboard (Tauri v2 — Rust + React/TypeScript) for stocks, crypto, and macroeconomics: watchlist with multi-indicator candlestick charts, 29 FRED macro series, cross-section percentile heatmap, and seven cross-asset analysis tools.

Privacy properties: no accounts, no telemetry, no analytics, no cloud sync. All state lives in a local SQLite file, and the only network requests are to the public data sources the user enables (FRED, Yahoo Finance quotes, optional RSS feeds).

---

### Supporting Material

- Source code: https://github.com/cerkon1/private-terminal
- Product page: https://www.privateacb.com/terminal/
- Privacy details: the README's "Privacy stance" section (including a full table of outbound network calls), and in-app at Settings → Privacy

---

### Affiliation

I am the author of Private Terminal.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
