### PR TITLE
Add Alacritty in Terminal Emulators

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4434,7 +4434,7 @@ categories:
       services:
       - name: Alacritty
         url: https://alacritty.org/
-        icon: https://alacritty.org/favicon.ico
+        icon: https://alacritty.org/alacritty-simple.svg
         github: alacritty/alacritty
         openSource: true
         description: |

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4434,6 +4434,7 @@ categories:
       services:
       - name: Alacritty
         url: https://alacritty.org/
+        icon: https://alacritty.org/favicon.ico
         github: alacritty/alacritty
         openSource: true
         description: |

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4431,7 +4431,14 @@ categories:
 
     - name: Terminal Emulators
       alternativeTo: ['putty', 'iterm2', 'gnome terminal', 'hyper', 'powershell']
-      services: []
+      services:
+      - name: Alacritty
+        url: https://alacritty.org/
+        github: alacritty/alacritty
+        openSource: true
+        description: |
+          Fast, GPU-accelerated terminal emulator focused on simplicity, performance,
+          and extensive keyboard-driven workflows.
 
   - name: Developer Utilities
     sections:


### PR DESCRIPTION
### Type

Addition 

---

### Changes

Added Alacritty to the Terminal Emulators section as a fast, GPU-accelerated, open-source terminal emulator focused on performance, simplicity, and keyboard-driven workflows.

Validation: make validate passed locally.

---

### Supporting Material

https://alacritty.org/
https://github.com/alacritty/alacritty

---

### Affiliation

I am not affiliated with Alacritty.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

