### PR TITLE
API run public for lib checks

### DIFF
--- a/.github/workflows/ci-api.yml
+++ b/.github/workflows/ci-api.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     paths:
       - 'api/**'
-      - 'awesome-privacy.yml'
       - '.github/workflows/ci-api.yml'
   workflow_dispatch:
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,5 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        '*': ref-pin

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -3,8 +3,8 @@ import { cors } from 'hono/cors'
 import { Scalar } from '@scalar/hono-api-reference'
 
 import { createStorage } from '@/lib/cache'
-import { errorHandler, notFound } from '@/lib/errors'
-import { requireBearer } from '@/lib/auth'
+import { ApiError, errorHandler, notFound } from '@/lib/errors'
+import { hasValidToken, authRequired } from '@/lib/auth'
 import { rateLimit } from '@/lib/ratelimit'
 import { newApp } from '@/lib/openapi'
 import type { AppEnv } from '@/types'
@@ -37,9 +37,8 @@ const buildPublic = () => {
 }
 
 const buildPrivate = () => {
-  // Private enrichment routes, bearer auth on every /enrich/* path
+  // Enrichment routes, public but rate-limited (see rate-limit wiring below)
   const priv = newApp()
-  priv.use('/enrich/*', requireBearer())
   priv.route('/', privacy)
   priv.route('/', github)
   priv.route('/', ios)
@@ -64,13 +63,21 @@ export const buildApp = () => {
     await next()
   })
 
-  // CORS everywhere; rate limiting and edge caching are for public routes only,
-  // authenticated /enrich/* requests are exempt from both
+  // CORS everywhere. Public browse routes get the standard limit; enrich routes
+  // are public too, but anonymous callers hit a stricter limit while a valid
+  // bearer token bypasses it. Edge caching stays off for enrich (below).
   app.use('*', cors({ origin: '*' }))
-  const limiter = rateLimit()
-  app.use('/v1/*', (c, next) =>
-    c.req.path.startsWith('/v1/enrich') ? next() : limiter(c, next),
-  )
+  const publicLimiter = rateLimit()
+  const enrichLimiter = rateLimit((env) => env.ENRICH_RATE_LIMIT ?? env.RATE_LIMIT)
+  app.use('/v1/*', (c, next) => {
+    if (!c.req.path.startsWith('/v1/enrich')) return publicLimiter(c, next)
+    const authed = hasValidToken(c.env.API_TOKEN, c.req.header('authorization'))
+    if (authRequired(c.env.REQUIRE_AUTH) && !authed) {
+      throw new ApiError('UNAUTHORIZED', 'Invalid or missing bearer token', 401)
+    }
+    if (authed) return next()
+    return enrichLimiter(c, next)
+  })
   app.use('/v1/*', async (c, next) => {
     if (c.req.path.startsWith('/v1/enrich')) return next()
     await next()
@@ -100,9 +107,12 @@ export const buildApp = () => {
 <details>
 <summary>Authenticating</summary>
 
-By default, no auth is needed.
-If you're self-hosting, you can enable auth by setting the \`API_TOKEN\` env var.
-Then, add the \`Authorization: Bearer <your-token>\` header when accessing the enrichment endpoints.
+The enrichment endpoints are public, but anonymous requests are rate-limited.
+On the hosted instance, sending a valid \`Authorization: Bearer <token>\` header
+exempts the request from rate limiting. Self-hosters can set the \`API_TOKEN\`
+env var to enable the same bypass for their own token.
+To lock the endpoints down entirely, set \`REQUIRE_AUTH\` (alongside \`API_TOKEN\`):
+requests without a valid token are then rejected with a 401.
 </details>
 
 <details>

--- a/api/src/lib/auth.ts
+++ b/api/src/lib/auth.ts
@@ -1,15 +1,12 @@
 /**
- * Middleware to add basic bearer token auth to /enrich/* routes
- * To prevent abuse of endpoints which make third-party requests
- * It's off-by-default, and can be enabled by setting API_TOKEN
- * Works by checking the "Authorization: Bearer $API_TOKEN" header
+ * Bearer token check for /enrich/* routes.
+ * The endpoints are public by default, but a request carrying the correct
+ * "Authorization: Bearer $API_TOKEN" header is exempt from rate limiting.
+ * When API_TOKEN is unset (e.g. self-hosted), no request is privileged.
+ * Setting REQUIRE_AUTH turns the token into a hard gate (see authRequired).
  */
 
-import type { MiddlewareHandler } from 'hono'
-import { ApiError } from '@/lib/errors'
-import type { HonoEnv } from '@/types'
-
-// Compare specified token against expected, using constant time
+// Compare two strings in constant time
 const constantTimeEqual = (left: string, right: string) => {
   if (left.length !== right.length) return false
   let diff = 0
@@ -19,14 +16,17 @@ const constantTimeEqual = (left: string, right: string) => {
   return diff === 0
 }
 
-// If auth enabled, check specified header matches env var, otherwise respond 401
-export const requireBearer = (): MiddlewareHandler<HonoEnv> => async (c, next) => {
-  const expected = c.env.API_TOKEN
-  if (!expected) return next()
-  const header = c.req.header('authorization') ?? ''
-  const match = /^Bearer\s+(\S+)$/i.exec(header)
-  if (!match || !constantTimeEqual(match[1], expected)) {
-    throw new ApiError('UNAUTHORIZED', 'Invalid or missing bearer token', 401)
-  }
-  await next()
+// True when a valid bearer token is present (auth must be configured)
+export const hasValidToken = (
+  expected: string | undefined,
+  header: string | undefined,
+): boolean => {
+  if (!expected) return false
+  const match = /^Bearer\s+(\S+)$/i.exec(header ?? '')
+  return !!match && constantTimeEqual(match[1], expected)
 }
+
+// True when REQUIRE_AUTH is enabled, hard-gating enrich behind a valid token.
+// Off by default; needs API_TOKEN set too, else every request fails closed.
+export const authRequired = (value: string | undefined): boolean =>
+  /^(1|true|yes|on)$/i.test(value ?? '')

--- a/api/src/lib/env.ts
+++ b/api/src/lib/env.ts
@@ -10,6 +10,7 @@ export const readEnv = (workersEnv?: Partial<AppEnv>): AppEnv => {
   const env = proc as Record<string, string | undefined>
   return {
     API_TOKEN: workersEnv?.API_TOKEN ?? env.API_TOKEN,
+    REQUIRE_AUTH: workersEnv?.REQUIRE_AUTH ?? env.REQUIRE_AUTH,
     DISCORD_BOT_TOKEN: workersEnv?.DISCORD_BOT_TOKEN ?? env.DISCORD_BOT_TOKEN,
     APIVOID_API_KEY: workersEnv?.APIVOID_API_KEY ?? env.APIVOID_API_KEY,
     EXODUS_TOKEN: workersEnv?.EXODUS_TOKEN ?? env.EXODUS_TOKEN,
@@ -17,6 +18,7 @@ export const readEnv = (workersEnv?: Partial<AppEnv>): AppEnv => {
     DOCKERHUB_TOKEN: workersEnv?.DOCKERHUB_TOKEN ?? env.DOCKERHUB_TOKEN,
     CACHE: workersEnv?.CACHE,
     RATE_LIMIT: workersEnv?.RATE_LIMIT,
+    ENRICH_RATE_LIMIT: workersEnv?.ENRICH_RATE_LIMIT,
     API_BASE: workersEnv?.API_BASE ?? env.API_BASE,
   }
 }

--- a/api/src/lib/ratelimit/index.ts
+++ b/api/src/lib/ratelimit/index.ts
@@ -2,19 +2,23 @@
  * Rate limit middleware factory
  * Basic measure to prevent obvious abuse for public routes
  * Uses CF's native rate-limiting API, configurable in wrangler.toml
- * Only applies to unauthenticated requests on the public instance
+ * The binding is selectable, so different routes can use different limits
  * By default, there's no rate-limiting on self-hosted/Bun versions
  */
 import type { MiddlewareHandler } from 'hono'
 import { ApiError } from '@/lib/errors'
-import type { HonoEnv } from '@/types'
+import type { AppEnv, HonoEnv, RateLimiter } from '@/types'
 
-export const rateLimit = (): MiddlewareHandler<HonoEnv> => async (c, next) => {
-  const limiter = c.env.RATE_LIMIT
-  if (!limiter) return next()
-  const key =
-    c.req.header('cf-connecting-ip') ?? c.req.header('x-forwarded-for') ?? 'anon'
-  const { success } = await limiter.limit({ key })
-  if (!success) throw new ApiError('RATE_LIMITED', 'Too many requests', 429)
-  return next()
-}
+export const rateLimit =
+  (
+    pick: (env: AppEnv) => RateLimiter | undefined = (env) => env.RATE_LIMIT,
+  ): MiddlewareHandler<HonoEnv> =>
+  async (c, next) => {
+    const limiter = pick(c.env)
+    if (!limiter) return next()
+    const key =
+      c.req.header('cf-connecting-ip') ?? c.req.header('x-forwarded-for') ?? 'anon'
+    const { success } = await limiter.limit({ key })
+    if (!success) throw new ApiError('RATE_LIMITED', 'Too many requests', 429)
+    return next()
+  }

--- a/api/src/types.ts
+++ b/api/src/types.ts
@@ -56,6 +56,8 @@ export interface RateLimiter {
 // Unified environment seen by both Workers + Node
 export interface AppEnv {
   API_TOKEN?: string
+  // When truthy, /enrich/* requires a valid bearer token (off by default)
+  REQUIRE_AUTH?: string
   DISCORD_BOT_TOKEN?: string
   APIVOID_API_KEY?: string
   EXODUS_TOKEN?: string
@@ -63,6 +65,7 @@ export interface AppEnv {
   DOCKERHUB_TOKEN?: string
   CACHE?: KVNamespace
   RATE_LIMIT?: RateLimiter
+  ENRICH_RATE_LIMIT?: RateLimiter
   API_BASE?: string
 }
 

--- a/api/tests/app.test.ts
+++ b/api/tests/app.test.ts
@@ -55,27 +55,80 @@ describe('public routes', () => {
   })
 })
 
-describe('auth', () => {
-  it('private route rejects missing token', async () => {
-    const res = await hit('/v1/enrich/privacy/1')
-    expect(res.status).toBe(401)
+describe('enrich rate limiting', () => {
+  // A limiter that always denies, recording how many times it was consulted
+  const denyLimiter = () => {
+    const calls = { n: 0 }
+    const limiter = {
+      limit: async () => {
+        calls.n++
+        return { success: false }
+      },
+    }
+    return { limiter, calls }
+  }
+  // A KV cache pre-seeded so handlers serve cached data without any upstream call
+  const seededCache = (value: unknown) => ({
+    get: async () => ({ value, cachedAt: Date.now() }),
+    put: async () => {},
   })
 
-  it('private route rejects wrong token', async () => {
-    const res = await hit('/v1/enrich/privacy/1', {
-      headers: { authorization: 'Bearer wrong' },
+  it('anonymous enrich request is rate-limited', async () => {
+    const { limiter, calls } = denyLimiter()
+    const res = await app.fetch(new Request('http://localhost/v1/enrich/privacy/1'), {
+      API_TOKEN: 'test',
+      ENRICH_RATE_LIMIT: limiter,
     })
-    expect(res.status).toBe(401)
+    expect(res.status).toBe(429)
+    expect(calls.n).toBe(1)
   })
 
-  it('security enrich route requires auth', async () => {
-    const res = await hit('/v1/enrich/security/jquery/jquery')
-    expect(res.status).toBe(401)
+  it('valid bearer token bypasses the enrich rate limit', async () => {
+    const { limiter, calls } = denyLimiter()
+    const res = await app.fetch(
+      new Request('http://localhost/v1/enrich/privacy/1', {
+        headers: { authorization: 'Bearer test' },
+      }),
+      { API_TOKEN: 'test', ENRICH_RATE_LIMIT: limiter, CACHE: seededCache({ id: 1 }) },
+    )
+    expect(res.status).toBe(200)
+    expect(calls.n).toBe(0)
   })
 
-  it('docker enrich route requires auth', async () => {
-    const res = await hit('/v1/enrich/docker/pihole')
-    expect(res.status).toBe(401)
+  it('wrong token does not bypass the enrich rate limit', async () => {
+    const { limiter, calls } = denyLimiter()
+    const res = await app.fetch(
+      new Request('http://localhost/v1/enrich/privacy/1', {
+        headers: { authorization: 'Bearer wrong' },
+      }),
+      { API_TOKEN: 'test', ENRICH_RATE_LIMIT: limiter },
+    )
+    expect(res.status).toBe(429)
+    expect(calls.n).toBe(1)
+  })
+
+  it('REQUIRE_AUTH rejects missing/invalid token with 401', async () => {
+    const env = { API_TOKEN: 'test', REQUIRE_AUTH: 'true' }
+    expect(
+      (await app.fetch(new Request('http://localhost/v1/enrich/privacy/1'), env)).status,
+    ).toBe(401)
+    const wrong = await app.fetch(
+      new Request('http://localhost/v1/enrich/privacy/1', {
+        headers: { authorization: 'Bearer wrong' },
+      }),
+      env,
+    )
+    expect(wrong.status).toBe(401)
+  })
+
+  it('REQUIRE_AUTH still admits a valid token', async () => {
+    const res = await app.fetch(
+      new Request('http://localhost/v1/enrich/privacy/1', {
+        headers: { authorization: 'Bearer test' },
+      }),
+      { API_TOKEN: 'test', REQUIRE_AUTH: 'true', CACHE: seededCache({ id: 1 }) },
+    )
+    expect(res.status).toBe(200)
   })
 })
 
@@ -86,7 +139,15 @@ describe('middleware scoping', () => {
   })
 
   it('enrich routes are not advertised as public cacheable', async () => {
-    const res = await hit('/v1/enrich/privacy/1')
+    // Seed the cache so the handler serves without an upstream call
+    const cache = {
+      get: async () => ({ value: { id: 1 }, cachedAt: Date.now() }),
+      put: async () => {},
+    }
+    const res = await app.fetch(new Request('http://localhost/v1/enrich/privacy/1'), {
+      API_TOKEN: 'test',
+      CACHE: cache,
+    })
     expect(res.headers.get('cache-control') ?? '').not.toContain('public')
   })
 })

--- a/api/wrangler.toml
+++ b/api/wrangler.toml
@@ -26,6 +26,13 @@ type = "ratelimit"
 namespace_id = "1001"
 simple = { limit = 60, period = 60 }
 
+# Stricter limit for anonymous /enrich/* requests; a valid API_TOKEN bypasses it
+[[unsafe.bindings]]
+name = "ENRICH_RATE_LIMIT"
+type = "ratelimit"
+namespace_id = "1002"
+simple = { limit = 10, period = 60 }
+
 # Scheduled cache warmer
 [triggers]
 crons = ["*/15 * * * *"]

--- a/lib/checks/check-project.py
+++ b/lib/checks/check-project.py
@@ -22,6 +22,8 @@ FINDINGS_PATH = "/tmp/findings-project.json"
 
 TIMEOUT = 10
 USER_AGENT = "awesome-privacy-ci/1.0"
+# Reachable but blocking automated probes (bot-block/rate-limit), not a missing page.
+SOFT_HTTP = {401, 403, 405, 406, 429}
 MIN_STARS = 100
 INACTIVE_DAYS = 90
 MIN_AGE_DAYS = 120
@@ -106,13 +108,13 @@ def load_diff(path):
 
 
 def check_url(url):
-    """Return True if the URL is reachable. Transport errors are treated as reachable."""
+    """Return True if reachable. Transport errors and bot-block/rate-limit statuses
+    (SOFT_HTTP) count as reachable; only a real bad status (404, 5xx, ...) fails."""
     ok, status = utils.check_url(url, SESSION, TIMEOUT)
-    if not ok:
-        logger.warning("URL check failed for %s (HTTP %d)", url, status)
-    elif status is None:
-        logger.warning("URL check error for %s (unreachable)", url)
-    return ok
+    if ok or status is None or status in SOFT_HTTP:
+        return True
+    logger.warning("URL check failed for %s (HTTP %d)", url, status)
+    return False
 
 
 def _gh_get(path, token, params=None, label=""):


### PR DESCRIPTION
### Type

Misc - API/lib script small change

---

### Changes
Can run lookup checks in anon mode.
Updated workflow not to trigger api checks when yaml change.
Committed my zizmor config, for the workflow audit

---

### Supporting Material
N/A

---

### Affiliation
N/A

---

### Checklist

- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

