### PR TITLE
Add Cypher eSIM to Virtual Phone Numbers

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1237,6 +1237,15 @@ categories:
           accepts crypto, doesn't KYC and you can delete your logs.
         acceptsCrypto: true
 
+      - name: Cypher eSIM
+        url: https://cypheresim.com
+        icon: https://cypheresim.com/logo.svg
+        acceptsCrypto: true
+        description: |
+          No-KYC travel eSIM for 180+ countries with 4G/5G data. No account, ID, or
+          email needed. Pay with crypto (BTC, USDT, SOL; Monero and TON coming soon)
+          and activate by QR in ~60 seconds. Available on the web and inside Telegram.
+
     ################################
     ###### Team Collaboration ######
     ################################


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds Cypher eSIM to the Virtual Phone Numbers section.

Cypher eSIM is a no-KYC travel eSIM for 180+ countries. No account, ID, or email is required. Users pick a plan, pay with crypto (BTC, USDT, SOL; Monero and TON being added), and activate by QR. It works on the web and entirely inside Telegram.

---

### Supporting Material

- Website: https://cypheresim.com
- Telegram bot: https://t.me/CypherESIM_bot

**On open source:** Cypher eSIM is a commercial service and is not open source. Per the guidelines, non-open-source submissions need justification: the Virtual Phone Numbers section already lists several closed-source providers in this category (Silent.link, PikaSim, nadanada, SMSPool). Cypher meets the same privacy bar (no-KYC, no logs, no account/ID/email, crypto payments).

---

### Affiliation

I am affiliated with this service — I work on Cypher eSIM. Disclosing for transparency.

---

### Checklist

- [x] I have read the Contributing guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories Contributor Covenant Code of Conduct