### PR TITLE
Adds qBittorrent to torrent clients

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5101,9 +5101,21 @@ categories:
     - name: Podcast Players
       alternativeTo: ['apple podcasts', 'spotify', 'google podcasts', 'pocket casts', 'overcast']
       services: []
+
     - name: Torrent Downloaders
       alternativeTo: ['utorrent', 'bittorrent', 'qBittorrent', 'deluge', 'transmission']
-      services: []
+      services:
+      - name: qBittorrent
+        url: https://www.qbittorrent.org
+        icon: https://avatars.githubusercontent.com/u/2131270?s=256&v=4
+        openSource: true
+        github: qbittorrent/qBittorrent
+        discordInvite: aCmFVmk
+        description: |
+          A cross-platform BitTorrent client with built-in torrent search, RSS feeds, and an optional web interface.
+          It contains no ads or bundled software.
+          As with any BitTorrent client, your IP address is visible to the peers and trackers you connect to.
+
     - name: File Converters
       alternativeTo: ['format factory', 'handbrake', 'freemake video converter', 'any video converter', 'online-convert.com']
       services:


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds qBittorrent
Closes #237

Risks,
- As with all torrenting IP exposure is the biggest risk, it's visible to every peer and tracker you connect to
- anonymous mode is off by default
- DHT / PeX / Local Peer Discovery are enabled by default
- Prior security issue (fixed now) whereby TLD certificates never validated
- Built-in search relies on user-added plugins, and is inherently risky
- GPL-2.0

Overall, qBittorrent is much more secure and private than the other options. Open source, widley used, includes anonymous mode, can be configured well for privacy, doesn't come bundled with anything bad


---

### Supporting Material
- Homepage: https://www.qbittorrent.org
- Source repo: https://github.com/qbittorrent/qBittorrent
- Documentation / Wiki: https://wiki.qbittorrent.org
- Security advisories: https://github.com/qbittorrent/qBittorrent/security/advisories
- Forum: https://forum.qbittorrent.org
- Bug tracker: https://bugs.qbittorrent.org
- Funding / donations: https://www.qbittorrent.org/donate
- Wikipedia: https://en.wikipedia.org/wiki/QBittorrent

---

### Affiliation
None, beyond occasional user (for Linux ISOs ofc 😉)

---

### Checklist

- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

