### PR TITLE
Removes AXP.OS due to the sole developer's death

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3922,15 +3922,6 @@ categories:
           A free and open-source operating system for various devices, based on the Android mobile platform - Lineage is light-weight, well maintained,
           supports a wide range of devices, and comes bundled with Privacy Guard.
 
-      - name: AXP.OS
-        url: https://axpos.org
-        git: https://git.disroot.org/AXP.OS
-        icon: https://axpos.org/favicon.svg
-        description: |
-          AXP.OS is an operating system based on AOSP & LineageOS. Emerged from the discontinued
-          [DivestOS](https://divestos-archive.codeberg.page), it aims to prolong the lifespan of discontinued
-          devices, enhance privacy and increase security where possible, e.g. by backporting kernel patches.
-
       notableMentions: |
         [Replicant OS](https://www.replicant.us/) is a fully-featured distro,
         with an emphasis on freedom, privacy and security.


### PR DESCRIPTION
### Type
Removal

### Changes
Two people in AXP.OS's Matrix room have confirmed the untimely death of the main (and sole) developer of the project. Given the usual spotless way of communicating by steadfasterX and his habit to announce when he would be offline for a while, the complete halt of development since the end of May, some server components going offline and the fact that anyone who tried to contact him since May 27th has failed, make the claim of his unfortunate death very persuasive.

Considering nobody seems to be capable of taking over the project (for now), it's best to remove it from the recommendations.

### Supporting Material
See above.

### Affiliation
Tester

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

