### PR TITLE
Adds AntennaPod to Podcase Players

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5103,9 +5103,21 @@ categories:
     - name: E-Book Readers
       alternativeTo: ['kindle', 'google play books', 'apple books', 'adobe digital editions', 'calibre']
       services: []
+
     - name: Podcast Players
       alternativeTo: ['apple podcasts', 'spotify', 'google podcasts', 'pocket casts', 'overcast']
-      services: []
+      services:
+      - name: AntennaPod
+        url: https://antennapod.org
+        icon: https://avatars.githubusercontent.com/u/10713470?s=256&v=4
+        followWith: Android
+        openSource: true
+        github: AntennaPod/AntennaPod
+        androidApp: de.danoeh.antennapod
+        description: |
+          An open-source podcast manager for Android. Subscribe to any RSS feed,
+          with offline downloads, variable playback speed, and optional gpodder.net or Nextcloud
+          sync. Contains no ads or trackers, but is Android-only, with no iOS or desktop app.
 
     - name: Torrent Downloaders
       alternativeTo: ['utorrent', 'bittorrent', 'qBittorrent', 'deluge', 'transmission']


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds AntennaPod to Podcast Players, closes #255

---

### Supporting Material

- Privacy policy: https://antennapod.org/privacy
- Website: https://antennapod.org
- Source: https://github.com/AntennaPod/AntennaPod
- Forum: https://forum.antennapod.org/

Pros
- Been around since 2011. Solid community
- Well-built (by actual humans!! rare these days), easily auditable code
- No privacy issues from the app, well scoped permissions, no trackers
- Works nicely, reliable, not bloated

Cons
- Discovery screen uses Apple Podcases, PodcastIndex, fyyd
- Doesn't have proxy or any protection for fetching feeds (they still see your IP)
- Playlists feature is basically non-existant
- Android only (it's java)
- Couldn't find security policy

---

### Affiliation
None

---

### Checklist

- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid Markdown formatting, spelling, and grammar)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

