### PR TITLE
Add CypherESIM (Virtual Phone Numbers)

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1237,6 +1237,16 @@ categories:
           accepts crypto, doesn't KYC and you can delete your logs.
         acceptsCrypto: true
 
+      - name: CypherESIM
+        url: https://cypheresim.com
+        icon: https://cypheresim.com/logo.svg
+        acceptsCrypto: true
+        description: |
+          Anonymous travel eSIM with 4G/5G data in 180+ countries. No account,
+          ID, email or phone number needed, no KYC. Paid in crypto (USDT, BTC,
+          ETH, USDC, XMR). eSIM activates in ~60 seconds.
+
+
     ################################
     ###### Team Collaboration ######
     ################################


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds **CypherESIM** to *Communication → Virtual Phone Numbers*. Anonymous travel eSIM with 4G/5G data in 180+ countries; no account, no ID, no email, no phone number; paid in crypto (USDT, BTC, ETH, USDC, XMR). eSIM activates in ~60 seconds.

This is a resubmission of an earlier PR (closed by @Lissy93). All technical concerns raised in that review have been addressed:

- **Google Analytics and Google Tag Manager removed from the site.** Verified live: no `dataLayer`, no `gtag`, no GTM container. Script count reduced from 9 to 6.
- **Privacy Policy rewritten to match reality.** It now matches the FAQ (no IP, no email, no name, no phone), explicitly names the only two third parties (upstream eSIM connectivity partner + crypto payment processor), and uses no behavioural or advertising tracking. Last updated 18 June 2026.
- **Mullvad mention removed** (no affiliation) and the inaccurate "Local SIM at the airport" comparison table removed.

Category fit matches existing entries Silent.link, Crypton.sh, nadanada, and PikaSim.

---

### Supporting Material
- Website: https://cypheresim.com
- Privacy Policy: https://cypheresim.com/privacy-policy
- Terms of Service: https://cypheresim.com/terms-of-service

---

### Affiliation
I am affiliated with CypherESIM (founder).

---

### Checklist
- [x] I have read the Contributing guide, and confirmed my PR aligns with requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repository's Contributor Covenant Code of Conduct