### PR TITLE
Adds gitgost into dev tools

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4457,6 +4457,15 @@ categories:
           Open-source, local-first API client that stores collections as plain text files
           and works seamlessly with Git. A privacy-focused alternative to cloud-based API tools.
 
+      - name: gitGost
+        url: https://gitgost.fly.dev
+        github: livrasand/gitGost
+        icon: https://avatars.githubusercontent.com/u/246907436?v=4
+        description: |
+          Push to GitHub anonymously: add gitGost as a git remote and it opens a pull request
+          with your name, email and commit metadata stripped, optionally over Tor. Anonymity
+          isn't perfect, and the hosted service has had abuse-related downtime.
+
   - name: Smart Home & IoT
     sections:
     - name: Voice Assistants


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds gitGost into developer tools/utils.

gitGost is an API and service which let's you create github issues and PRs which come from the @gitgost-anonymous bot account, rather than your real/personal account. 


---

### Supporting Material

Links:
- Repo: https://github.com/livrasand/gitGost
- Website: https://gitgost.fly.dev
- Author: @livrasand

Pros:
- Let's you make GitHub contributions without having a GH/Microsoft account
- Their docs do a good job at listing what GitGost does NOT protect against. It's transparent and not over-stated. 
- Can be self-hosted (but I've not tried), however it's usefulness for anonymity slightly comes from having multiple users
- Genuinely useful and unique
- Code seems fine, can't see major quality, security or maintainability issues


Concerns/notes:
- Project is relatively young (7 months), but so far well maintained
- Uses just one bot account which is a single point of failure if it gets shut down by GitHub
  - There is some mitigation against this: author has got sensible rate limits, blocking, and has their own abuse reporting (so _hopefully_ people don't report/flag the main account to github)
  - Also seems like it would be relatively easy to create new account, and just update the `GITHUB_TOKEN` and it will work again
- I'm unsure if this is inline with GitHub's terms of service, but couldn't find anything saying it wasn't allowed (and I have used a github bot account for years, with no issue (it will comment below shortly!)) 
- It will become more anonymous the more users use it. While it's still relatively small, you can possibly draw trends between contributions, so I suggested making @gitgost-anonymous's contribution history private on GitHub (see: https://github.com/livrasand/gitGost/issues/79)
- Using gitGost you place your trust in the gitGost server (they see your original commit data, IP and of course the full body of your changes)
- Could be prone to abuse, but as mentioned there are some safeguards around this
- Website missing a privacy policy for the public instance, but there is [this doc](https://github.com/livrasand/gitGost/blob/main/Privacy%20Guarantees.md)
- There is a security policy (in [security.md](https://github.com/livrasand/gitGost/security)). No security.txt or github advisories

---

### Affiliation
I've been an occasional user, I've submitted issues/bugs to the repo.
But no affiliation beyond that.

---

### Checklist
- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

