### PR TITLE
Moves developer tools into development section

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4434,8 +4434,6 @@ categories:
           Fast, GPU-accelerated terminal emulator focused on simplicity, performance,
           and extensive keyboard-driven workflows.
 
-  - name: Developer Utilities
-    sections:
     - name: Developer Tools
       services:
       - name: DevToys


### PR DESCRIPTION
### Type
Amendment

---

### Changes
I just moved developer utilities into Development category.
Unsure why this was in it's own category previously, looks like it was a mistake I made in #458

---

### Supporting Material
N/A

---

### Affiliation
N/A

---

### Checklist
- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
