### PR TITLE
Add MirrorNotes to Digital Notes — on-device AI journaling for iOS

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3012,6 +3012,21 @@ categories:
           (yay, dark mode!), and it features built-in secure file store, tags/ folders, fast search and more.
           Standard Notes is actively developed, and fully open-source.
 
+      - name: MirrorNotes
+        url: https://mirrornotes.org
+        followWith: iOS (iPhone)
+        openSource: false
+        securityAudited: false
+        icon: https://mirrornotes.org/og-image.png
+        iosApp: https://apps.apple.com/app/id6769007201
+        description: |
+          A private journaling app for iPhone where all AI runs on-device (Gemma 3 1B via CoreML).
+          Journal text is never transmitted — no cloud AI, no server, no API calls. Features include
+          daily personalized reflection prompts, natural language queries over entries ("Ask your journal"),
+          mood tracking and timeline, weekly digest, and monthly deep report — all running locally on
+          the iPhone's Neural Engine. Works fully offline. Free to write forever; AI features
+          $2.99–$4.99/mo with a 7-day trial via Apple IAP.
+
       - name: Turtle
         url: https://turtlapp.com
         icon: https://turtlapp.com/images/logo.svg


### PR DESCRIPTION
## What this adds

[MirrorNotes](https://mirrornotes.org) — an iOS journaling app where all AI runs on-device (Gemma 3 1B via CoreML). Added to the Digital Notes section.

## Why it fits

**Privacy is architectural, not a promise:**
- Journal text is never transmitted — there is no cloud AI code path in the app
- Gemma 3 runs on the iPhone's Neural Engine; no API calls to Anthropic, OpenAI, or anyone
- Works fully offline including all AI features
- No account required

**What differentiates it from the other Digital Notes entries:**
- The only journaling-focused app in this section with fully on-device AI inference
- Every AI feature (daily prompts, natural language queries, mood analysis, weekly/monthly summaries) runs locally — not a cloud integration
- iOS only — a deliberate tradeoff to ship a single model that runs on Apple's Neural Engine

**Pricing:** Free to write forever. AI features $2.99–$4.99/mo with 7-day trial via Apple IAP.

App Store: https://apps.apple.com/app/id6769007201
Website: https://mirrornotes.org