### PR TITLE
Add VidKit in Creativity ▸ Video Editors

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5339,6 +5339,17 @@ categories:
         github: NatronGitHub/Natron
         icon: https://natrongithub.github.io/img/Natron_icon.svg
         openSource: true
+      - name: VidKit
+        followWith: Browser
+        description: |
+          A free, in-browser video compressor and format converter (MP4, MOV, MKV,
+          WebM, MP3, GIF). All processing runs locally via WebCodecs with an
+          ffmpeg.wasm fallback, so files are never uploaded — no server, no cookies,
+          no accounts. The zero-upload guarantee is enforced by an automated test.
+        url: https://vidkit.eu
+        github: TondaRuzicka/vidkit
+        icon: https://vidkit.eu/favicon.svg
+        openSource: true
 
     - name: Audio Editors & Recorders
       alternativeTo: ['adobe audition', 'garageband', 'fl studio', 'ableton live']


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds VidKit as the last entry under Creativity ▸ Video Editors. VidKit is a free, browser-based video compressor and format converter (MP4, MOV, MKV, WebM, MP3, GIF). All processing runs locally in the browser using the WebCodecs API, with an ffmpeg.wasm fallback for unsupported codecs; no file data is transmitted to any server. The entry follows the existing service schema (`url`, `github`, `icon`, `openSource`, `followWith: Browser`, block-scalar `description`). Only `awesome-privacy.yml` was edited; the README is left untouched. YAML validated with `js-yaml`.

---

### Supporting Material
- Website: https://vidkit.eu
- Source (MIT): https://github.com/TondaRuzicka/vidkit
- Privacy model: all processing is client-side (WebCodecs + ffmpeg.wasm fallback). No accounts, no consent-requiring cookies, cookieless aggregate pageview stats only. The zero-upload guarantee is covered by an automated test in the repo.

---

### Affiliation
I am the author of VidKit.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
