### PR TITLE
Add captchaapi to Developer Tools

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4484,6 +4484,16 @@ categories:
           with your name, email and commit metadata stripped, optionally over Tor. Anonymity
           isn't perfect, and the hosted service has had abuse-related downtime.
 
+      - name: captchaapi
+        url: https://captchaapi.eu
+        icon: https://captchaapi.eu/favicon.ico
+        description: |
+          EU-hosted CAPTCHA that verifies users are human with a proof-of-work challenge
+          instead of behavioral tracking. It sets no cookies, loads no third-party trackers,
+          and keeps all data within the EU under GDPR. A privacy-respecting alternative to
+          reCAPTCHA, hCaptcha and Turnstile, with drop-in SDKs (including Laravel) and a
+          plain JavaScript widget.
+
   - name: Smart Home & IoT
     sections:
     - name: Voice Assistants


### PR DESCRIPTION
captchaapi.eu is an EU-hosted CAPTCHA I built as a privacy-first alternative to reCAPTCHA. It uses a proof-of-work challenge to tell humans from bots, so it sets no cookies, loads no third-party trackers, and keeps all data inside the EU under GDPR. The privacy policy is public at https://captchaapi.eu/legal/privacy.

I placed it under Developer Tools since that is the closest existing section, but feel free to move it if you would rather group CAPTCHA services somewhere else. Only awesome-privacy.yml is edited; the README is left for the generator.