### PR TITLE
Add AI Notebook (offline, local NotebookLM alternative)

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3012,20 +3012,6 @@ categories:
           (yay, dark mode!), and it features built-in secure file store, tags/ folders, fast search and more.
           Standard Notes is actively developed, and fully open-source.
 
-      - name: AI Notebook
-        url: https://github.com/lukoplt/AI-notebook
-        github: lukoplt/AI-notebook
-        followWith: Windows, MacOS
-        openSource: true
-        securityAudited: false
-        icon: https://raw.githubusercontent.com/lukoplt/AI-notebook/main/docs/icon.png
-        description: |
-          AI Notebook is a free, open-source, offline alternative to Google NotebookLM. Chat with your
-          own documents (PDFs, Office files, web pages) and get answers with inline citations — the
-          embeddings, retrieval and chat all run locally on your machine via Ollama, so your files are
-          never uploaded anywhere. It also includes a notes editor and hybrid local search (vector +
-          full-text). Native macOS and Windows desktop apps, MIT licensed.
-
       - name: Turtle
         url: https://turtlapp.com
         icon: https://turtlapp.com/images/logo.svg
@@ -3119,6 +3105,18 @@ categories:
         description: |
           A free, open-source note-taking application built with Qt, focused on providing a pleasant Markdown
           editing experience. It manages notes directly as plain text files on your local system.
+
+      - name: AI Notebook
+        url: https://github.com/lukoplt/AI-notebook
+        github: lukoplt/AI-notebook
+        followWith: Windows, MacOS
+        openSource: true
+        securityAudited: false
+        icon: https://raw.githubusercontent.com/lukoplt/AI-notebook/main/docs/icon.png
+        description: |
+          A free, open-source, offline alternative to Google NotebookLM for macOS and Windows. Chat with
+          your own documents and get answers with citations, all running locally via Ollama, so your files
+          are never uploaded.
 
       notableMentions: |
         If you are already tied into Evernote, One Note etc, then [SafeRoom](https://www.getsaferoom.com)

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3012,6 +3012,20 @@ categories:
           (yay, dark mode!), and it features built-in secure file store, tags/ folders, fast search and more.
           Standard Notes is actively developed, and fully open-source.
 
+      - name: AI Notebook
+        url: https://github.com/lukoplt/AI-notebook
+        github: lukoplt/AI-notebook
+        followWith: Windows, MacOS
+        openSource: true
+        securityAudited: false
+        icon: https://raw.githubusercontent.com/lukoplt/AI-notebook/main/docs/icon.png
+        description: |
+          AI Notebook is a free, open-source, offline alternative to Google NotebookLM. Chat with your
+          own documents (PDFs, Office files, web pages) and get answers with inline citations — the
+          embeddings, retrieval and chat all run locally on your machine via Ollama, so your files are
+          never uploaded anywhere. It also includes a notes editor and hybrid local search (vector +
+          full-text). Native macOS and Windows desktop apps, MIT licensed.
+
       - name: Turtle
         url: https://turtlapp.com
         icon: https://turtlapp.com/images/logo.svg


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds **AI Notebook** to Productivity → Digital Notes (appended to the end of the section).

AI Notebook is a native macOS and Windows desktop app for question-answering over your own documents (PDF, Office files, web pages, plain text). Embeddings, retrieval, notes, and chat run locally via Ollama, and documents are not uploaded. On Windows, optional cloud providers (Anthropic / OpenAI) can be configured by the user. MIT licensed.

---

### Supporting Material
- Repository: https://github.com/lukoplt/AI-notebook
- Releases (macOS `.dmg` + Windows `.exe`): https://github.com/lukoplt/AI-notebook/releases
- License: [MIT](https://github.com/lukoplt/AI-notebook/blob/main/LICENSE)

---

### Affiliation
I am the author of AI Notebook. For full transparency, and consistent with your bot's detection: the application is developed with substantial AI assistance, and this submission was also prepared with AI help. The app is a real, working, actively-maintained cross-platform project; I'm happy to provide any further detail.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
