### PR TITLE
Adds 0xEsim to Virtual Phone Numbers

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1181,6 +1181,14 @@ categories:
           + world-wide roaming. No data is required at sign-up. Affordable pricing, with
           payments and top-ups accepted in BTC. Requires an eSim-compatible device.
 
+      - name: 0xEsim
+        url: https://0xesim.io
+        icon: https://0xesim.io/favicon.ico
+        acceptsCrypto: true
+        description: |
+          No-KYC eSIM for 190+ countries. No account, no ID, no email required.
+          Pay with Monero, USDT and other crypto. Transparent IP breakout routing.
+
       - name: Crypton.sh
         url: https://crypton.sh/
         icon: https://crypton.sh/assets/shared/icons/favicon-32x32.png


### PR DESCRIPTION
Adds 0xEsim to Communication > Virtual Phone Numbers.

0xEsim (https://0xesim.io) is a no-KYC eSIM covering 190+ countries. No
account, no ID and no email are required — you pay in crypto (Monero, USDT
and others) and receive the eSIM QR by email in minutes. It also exposes a
transparent per-plan IP breakout country.

This sits alongside the existing entries in the same section (Silent.link,
Crypton.sh, PikaSim, nadanada), which are all no-KYC crypto eSIM / number services.

Checklist:
- [x] Description is 50-250 chars and non-promotional
- [x] Entry added to awesome-privacy.yml (not README)
- [x] icon URL resolves (https://0xesim.io/favicon.ico)

Disclosure / affiliation: I'm affiliated with 0xEsim.