### PR TITLE
Adds Spectre Android app to Mobile Apps

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1796,6 +1796,15 @@ categories:
           F-Droid is an installable catalogue of FOSS applications for Android. The client enables you
           to browse, install, and keep track of updates on your device.
 
+      - name: Spectre
+        url: https://github.com/thomasbuilds/Spectre
+        github: thomasbuilds/Spectre
+        openSource: true
+        icon: https://raw.githubusercontent.com/thomasbuilds/Spectre/5e915a8d4e1daa550fd9acc063b963732b64b863/icon.png
+        androidApp: dev.thomasbuilds.spectre
+        description: |
+          A radio frequency scanner app for Android with recon and offensive capabilities.
+
       wordOfWarning: |
         Too many installed apps will increase your attack surface - only install applications that you need.
         Be sure to check the permissions, and what data an app has access to prior to installation.

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1800,7 +1800,7 @@ categories:
         url: https://github.com/thomasbuilds/Spectre
         github: thomasbuilds/Spectre
         openSource: true
-        icon: https://raw.githubusercontent.com/thomasbuilds/Spectre/5e915a8d4e1daa550fd9acc063b963732b64b863/icon.png
+        icon: https://raw.githubusercontent.com/thomasbuilds/Spectre/refs/heads/main/metadata/en-US/images/icon.png
         androidApp: dev.thomasbuilds.spectre
         description: |
           A radio frequency scanner app for Android with recon and offensive capabilities.


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds Spectre into Security Tools -> Mobile App

> Spectre is an Android app for observing and interacting with the wireless environment around you. It monitors signals from Bluetooth devices, Wi-Fi access points, cellular towers, and GNSS satellites. Spectre also features a growing set of pentesting tools, constrained by Android's security model.

---

### Supporting Material

Links:

- Repo: https://github.com/thomasbuilds/Spectre
- Author: @thomasbuilds

Pros:

- Lets you see the radio environment around you in one place.
- Good documentation highlighting Android limitations.
- It's coded in Kotlin, with CodeQL workflows running on every commit and immutable releases.

Concerns/notes:

- Project is young (~1 month), but well maintained and gaining traction

---

### Affiliation

I'm using the app and I've submitted 1 issue and 1 PR to the repo so far.
But no affiliation beyond that.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)