### PR TITLE
Update PikaSim: add phone numbers, shielded Zcash, 190+ countries

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1215,8 +1215,10 @@ categories:
         icon: https://pikasim.com/img/pika-transparent.png
         acceptsCrypto: true
         description: |
-          Privacy-focused eSIM provider for 170+ countries, with instant eSIM delivery.
-          No account, ID, email needed, and accepts crypto via a self-hosted BTCPay Server.
+          Privacy-focused eSIM provider for 190+ countries, plus real carrier phone numbers
+          (voice, SMS and data) with a genuine +1 or one of 157 country numbers. Instant
+          delivery, no account, ID or email needed. Pays via a self-hosted BTCPay Server,
+          accepting Bitcoin, Lightning, Monero and shielded Zcash.
 
       - name: nadanada
         url: https://nadanada.me


### PR DESCRIPTION
Refreshes the existing **PikaSim** entry under Communication → Virtual Phone Numbers.

Since the entry was added, PikaSim has:
- launched **real carrier phone numbers** (voice, SMS and data; a genuine +1 or one of 157 country numbers), which is why it fits this category more directly, and
- added **shielded Zcash** alongside Bitcoin, Lightning and Monero (all via a self-hosted BTCPay Server).

Also updated the country count 170 → 190. Description length and `acceptsCrypto` flag stay consistent with neighboring entries (Silent.link, nadanada). YAML structure/indentation unchanged.

Authored-by: CodeBru [codebru.com]