### PR TITLE
feat: add CyberForget to Data Broker Removal section

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5457,7 +5457,7 @@ categories:
         github: https://github.com/aseprite/aseprite
         openSource: true
   - name: Data Broker Removal
-    services:
+    sections:
       - name: CyberForget
         url: https://cyberforget.com
         description: |

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5456,5 +5456,14 @@ categories:
         description: An animated sprite editor & pixel art tool for Windows, macOS and Linux.
         github: https://github.com/aseprite/aseprite
         openSource: true
-
+  - name: Data Broker Removal
+    services:
+      - name: CyberForget
+        url: https://cyberforget.com
+        description: |
+          Automated data broker removal service that scans 200+ data broker and people-search sites
+          for your personal information and submits opt-out requests on your behalf.
+          Features include free data breach scanning, continuous monitoring for re-appearance,
+          and automatic re-removal of re-listed data. No signup required for basic scanning.
+        icon: https://cyberforget.com/og-home.png
 

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5456,14 +5456,15 @@ categories:
         description: An animated sprite editor & pixel art tool for Windows, macOS and Linux.
         github: https://github.com/aseprite/aseprite
         openSource: true
-  - name: Data Broker Removal
-    sections:
-      - name: CyberForget
-        url: https://cyberforget.com
-        description: |
-          Automated data broker removal service that scans 200+ data broker and people-search sites
-          for your personal information and submits opt-out requests on your behalf.
-          Features include free data breach scanning, continuous monitoring for re-appearance,
-          and automatic re-removal of re-listed data. No signup required for basic scanning.
-        icon: https://cyberforget.com/og-home.png
+  
+    - name: Data Broker Removal
+      services:
+        - name: CyberForget
+          url: https://cyberforget.com
+          description: |
+            Automated data broker removal service that scans 200+ data broker and people-search sites
+            for your personal information and submits opt-out requests on your behalf.
+            Features include free data breach scanning, continuous monitoring for re-appearance,
+            and automatic re-removal of re-listed data. No signup required for basic scanning.
+          icon: https://cyberforget.com/og-home.png
 


### PR DESCRIPTION
This PR adds a new **Data Broker Removal** section to the list, starting with [CyberForget](https://cyberforget.com) — an automated data broker removal service that scans 200+ data broker and people-search sites for your personal information and submits opt-out requests on your behalf.

CyberForget is free to scan (no signup required) and covers opt-outs from data brokers that collect and sell personal data. It fits well under the privacy tools umbrella given the growing concern around data broker exposure.

Closes: N/A