### PR TITLE
[Add] Quota Dashboard in Developer Tools

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4484,6 +4484,17 @@ categories:
           with your name, email and commit metadata stripped, optionally over Tor. Anonymity
           isn't perfect, and the hosted service has had abuse-related downtime.
 
+      - name: Quota Dashboard
+        url: https://ryan-knowone.github.io/quota-dashboard/
+        github: ryan-knowone/quota-dashboard
+        icon: https://raw.githubusercontent.com/ryan-knowone/quota-dashboard/main/favicon.svg
+        openSource: true
+        description: |
+          Open-source, local-only dashboard that shows remaining AI subscription quota for
+          Claude Code Max, Kimi, and Z.ai. Tokens stay in the browser and are never sent to
+          the app's server; provider APIs are called directly. Live mock mode lets reviewers
+          preview the UI without credentials.
+
   - name: Smart Home & IoT
     sections:
     - name: Voice Assistants

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4490,10 +4490,9 @@ categories:
         icon: https://raw.githubusercontent.com/ryan-knowone/quota-dashboard/main/favicon.svg
         openSource: true
         description: |
-          Open-source, local-only dashboard that shows remaining AI subscription quota for
-          Claude Code Max, Kimi, and Z.ai. Tokens stay in the browser and are never sent to
-          the app's server; provider APIs are called directly. Live mock mode lets reviewers
-          preview the UI without credentials.
+          Open-source, local-only dashboard for remaining AI subscription quota (Claude Code
+          Max, Kimi, Z.ai). Tokens stay in the browser; provider APIs are called directly.
+          Mock mode lets reviewers preview without credentials.
 
   - name: Smart Home & IoT
     sections:


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds [Quota Dashboard](https://github.com/ryan-knowone/quota-dashboard) to the Developer Tools section. It is an open-source, local-only dashboard that shows remaining AI subscription quota for Claude Code Max, Kimi, and Z.ai. Tokens stay in the browser and are never sent to the app's server; provider APIs are called directly from the client. A live mock mode lets reviewers preview the UI without credentials: https://ryan-knowone.github.io/quota-dashboard/?mock=1

---

### Supporting Material
- GitHub repo: https://github.com/ryan-knowone/quota-dashboard
- Live demo: https://ryan-knowone.github.io/quota-dashboard/
- Mock-mode preview: https://ryan-knowone.github.io/quota-dashboard/?mock=1
- LICENSE: MIT

---

### Affiliation
I am the maintainer of Quota Dashboard (ryan-knowone).

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/CODE_OF_CONDUCT.md)

![good bot](https://pixelflare.cc/alicia/images/ralph-can-code.gif/w512)