### PR TITLE
Adds In Case to Password Managers

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -114,7 +114,17 @@ categories:
           AliasVault protects your privacy by creating alternative identities, passwords
           and email addresses for every website you use. Use the cloud version, or self-host and
           deploy within minutes via Docker.
-
+      - name: In Case
+        url: https://in-case.me
+        github: wulongwangpeng-jpg/in-case.me
+        openSource: true
+        icon: https://in-case.me/favicon.ico
+        description: |
+          Zero-knowledge encrypted vault focused on the "what happens to my accounts
+          if I can't log in" problem. Browser-side AES-256-GCM encryption means the server
+          never sees plaintext — contacts get access only after a configurable quiet period.
+          Open source (AGPL-3.0), independently built, no tracking. Not a full password
+          manager; solves digital account transition planning.
       notableMentions:
       - name: Password Safe
         url: https://www.pwsafe.org


### PR DESCRIPTION
### Type
Addition

### Changes
Added In Case to Password Managers — a zero-knowledge encrypted vault for digital account transition planning. Browser-side AES-256-GCM encryption, AGPL-3.0 licensed, open source with no tracking or ads.

---

## ➕ Adds In Case to Password Managers

**Name:** In Case
**URL:** https://in-case.me
**Repository:** https://github.com/wu
**License:** AGPL-3.0

### Why this belongs here

In Case is a privacy-first digital safety net tool:
- **Zero-knowledge** — AES-256-GCM eneb Crypto API. The server stores onlyciphertext + salt + IV. We literally cannot read user data.
- **Open source** — Full source availe and auditable.
- **No tracking, no ads, no third-party scripts** — revenue comes from subscriptions, not data.
- **Browser-side only** — encryption client, never on the server.
- **Independently built** — solo developer, bootstrapped, no VC.

### Disclosure

I am the developer of In Case. Adding it because it meets the privacy criteria: open source,
zero-knowledge, client-side encryptioarent business model.

### Checklist

- [x] Privacy respecting (no unnecesside encryption)
- [x] Secure (AES-256-GCM, PBKDF2, Web Crypto API; no known CVEs)
- [x] Open source (AGPL-3.0)
- [x] Actively maintained (commits within last 7 days)
- [x] Transparent (solo dev, subscriptations)
- [x] Functional (stable, publicly accessible, documented)
- [x] Fits existing category (Passwor / digital legacy adjacent)