### PR TITLE
Adds VESmail to Email Security Tools

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1098,6 +1098,16 @@ categories:
           Verifies DKIM signatures and shows the result in the e-mail header, in order to help
           spot spoofed emails (which do not come from the domain that they claim to).
 
+      - name: VESmail
+        url: https://vesmail.email
+        icon: https://vesmail.email/favicon.ico
+        openSource: true
+        github: vesvault/VESmail
+        description: |
+          Self-hosted IMAP/SMTP proxy that end-to-end encrypts mail for any existing
+          email account, without changing clients or providers. Keys are recoverable
+          via the VESvault key repository, which the proxy depends on for key exchange.
+
       notableMentions: >
         If you are using ProtonMail, then the [ProtonMail Bridge](https://protonmail.com/bridge/thunderbird)
         enables you to sync & backup your emails to your own desktop mail client.


### PR DESCRIPTION

### Type
Addition

---

### Changes
Adds VESmail to Communication → Email Security Tools.

VESmail is a self-hosted IMAP/SMTP proxy that adds end-to-end encryption to an existing email account — mail clients and providers keep working unchanged, and message bodies/attachments are encrypted before they reach the mail server. Key exchange and recovery run through the VESvault key repository, which the proxy depends on (stated as a drawback in the description).

Drafted with AI assistance; reviewed, tested and submitted by the maintainer.

---

### Supporting Material
- Source: https://github.com/vesvault/VESmail (Apache-2.0, C)
- Site + docs: https://vesmail.email
- Underlying E2EE library: https://github.com/vesvault/libVES.c

---

### Affiliation
I am the author/maintainer of VESmail (VESvault Corp).

---

### Checklist
- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

