### PR TITLE
Remove VESmail from Email Security Tools

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1107,16 +1107,6 @@ categories:
           Verifies DKIM signatures and shows the result in the e-mail header, in order to help
           spot spoofed emails (which do not come from the domain that they claim to).
 
-      - name: VESmail
-        url: https://vesmail.email
-        icon: https://vesmail.email/favicon.ico
-        openSource: true
-        github: vesvault/VESmail
-        description: |
-          Self-hosted IMAP/SMTP proxy that end-to-end encrypts mail for any existing
-          email account, without changing clients or providers. Keys are recoverable
-          via the VESvault key repository, which the proxy depends on for key exchange.
-
       notableMentions: >
         If you are using ProtonMail, then the [ProtonMail Bridge](https://protonmail.com/bridge/thunderbird)
         enables you to sync & backup your emails to your own desktop mail client.


### PR DESCRIPTION
### Type
Removal

---

### Changes
Reverts #662 
To remove VESmail from email security tools

---

### Supporting Material
Waiting for clarification from @vesvault-jz on this, but it looks like there may be some privacy/security concerns. 

It's possible to audit and self-host the email proxy, relay and even PIN-throttle server. But the main trust point is the server, which uses their own propriety hosted backend.

This wasn't mentioned in the original PR submitted. Which felt slightly deceptive. Since without transparency around this, I _think_ that:
1. Your email credentials are stored by VES
2. You will loose decryption access to all mail if their service becomes unavailable
3. E2E encryption and all other claims are unverified
4. VES is the single-point of trust and failure.
5. Increases attack surface, suseptible to social engineering

And:
- Both apps already have gone offline: https://vesmail.email/download
- Seems quite scattered: https://ves.host, https://vesmail.email, https://www.vesvault.com
- Original code was solid. But the repos seem to of been taken over by AI slop, with sudden drop in quality
- Usage docs mean this isn't user-friendly, getting setup and working (admittedly in demo vm) has been impossible
- Account setup broken: "There might be a problem with the email address you entered. Double check the email address at the top right corner." - for totally valid, working emails.


---

### Affiliation
None

---

### Checklist
- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
