### PR TITLE
Add Tomatoes.run in Mail Forwarding

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1083,6 +1083,15 @@ categories:
           If you already have ProtonMail's Professional (€8/month) or Visionary (€30/month) package,
           then an implementation of this feature is available via the Catch-All Email feature.
 
+      - name: Tomatoes.run
+        url: https://www.tomatoes.run
+        icon: https://www.tomatoes.run/icon.svg
+        openSource: false
+        description: |
+          Email aliasing through a personal subdomain (you.tomatoes.run): every address
+          forwards to your inbox, no alias to create first. Closed-source, France-hosted;
+          no custom domains or reply support. Free tier (5 aliases), €5/mo unlimited.
+          
     ##################################
     ###### Mail Security Tools ######
     #################################


### PR DESCRIPTION
### Type
Addition

### Changes
Adds Tomatoes.run to the Mail Forwarding section. It's an email aliasing service using a
per-subdomain catch-all: any address on your `you.tomatoes.run` subdomain forwards to your
inbox with no alias created beforehand, and mail is never stored. The description also notes
the trade-offs (closed-source, France-only hosting, no custom domains, no reply support).

### Supporting Material
- Homepage: https://www.tomatoes.run
- Privacy policy: https://www.tomatoes.run/legal/privacy
- Terms: https://www.tomatoes.run/legal/terms
(No public source repository; no third-party security audit.)

### Affiliation
Yes — I'm the creator/maintainer of Tomatoes.run.

### Checklist
- [x] I have read the Contributing guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repository's Contributor Covenant Code of Conduct