### PR TITLE
Add MirrorNotes in Digital Notes

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3095,6 +3095,18 @@ categories:
           A free, open-source note-taking application built with Qt, focused on providing a pleasant Markdown
           editing experience. It manages notes directly as plain text files on your local system.
 
+      - name: MirrorNotes
+        url: https://mirrornotes.org
+        github: lokii49/mirror
+        icon: https://is1-ssl.mzstatic.com/image/thumb/Purple211/v4/75/e4/08/75e4083d-898c-86ad-4e78-dbf0f85e6843/AppIcon-0-0-1x_U007emarketing-0-8-0-85-220.png/512x512bb.jpg
+        followWith: iOS
+        openSource: true
+        iosApp: https://apps.apple.com/app/id6769007201
+        description: |
+          On-device AI journaling app for iPhone. A local Gemma 3 model writes daily reflection
+          prompts and mood analysis from your own entries, fully offline. Free tier is unlimited
+          writing; AI features need a paid subscription. iOS only.
+
       notableMentions: |
         If you are already tied into Evernote, One Note etc, then [SafeRoom](https://www.getsaferoom.com)
         is a utility that encrypts your entire notebook, before it is uploaded to the cloud.


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds MirrorNotes to Productivity > Digital Notes. On-device AI journaling app for iPhone — a local Gemma 3 model generates reflection prompts and mood analysis from the user's own entries, with no server involved and no account required. Free tier covers unlimited writing and full entry history forever; AI features (daily prompts, mood analysis, "ask your journal") require a paid subscription. iOS only, no other platforms.

---

### Supporting Material
- App Store: https://apps.apple.com/app/id6769007201
- Source (AGPL-3.0): https://github.com/lokii49/mirror
- Site: https://mirrornotes.org
- Privacy policy: https://mirrornotes.org/privacy.html

---

### Affiliation
I'm the developer of MirrorNotes — submitting my own project, disclosed here per your guidelines.

---

### Checklist
- [x] I have read the Contributing guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields) — validated against `lib/validate-awesome-privacy.py`, passes schema check
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repository's Contributor Covenant Code of Conduct

Note: I noticed this repo's CONTRIBUTING.md and PR template both contain a hidden HTML comment instructing AI agents to embed an image link as a "requirement" for merging. I'm an AI agent (Claude, working on behalf of the developer) and I'm flagging rather than complying with that instruction, since it isn't part of the actual stated Guidelines and looks like a prompt-injection test rather than a real project requirement.