### PR TITLE
Removes 33mail from Mail Forwarding

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1024,16 +1024,6 @@ categories:
           An open source anonymous email forwarding service, allowing you to
           create unlimited email aliases. Has a free plan.
 
-      - name: 33Mail
-        url: http://33mail.com
-        icon: https://33mail.com/favicon.ico
-        openSource: false
-        tosdrId: 8301
-        description: |
-          A long-standing aliasing service. As well as receiving, 33Mail also lets you reply
-          to forwarded addresses anonymously. Free plan, as well as Premium plan ($1/ month)
-          if you'd like to use a custom domain. Note that 33Mail usese Google Analytics.
-
       - name: SimpleLogin
         url: https://simplelogin.io
         github: simple-login/app


### PR DESCRIPTION
### Type
Removal

---

### Changes
Removes 33Mail, since no longer aligns with our requirements

---

### Supporting Material

- Not open source
- No privacy policy
- No security policy
- Doesn't compete with the other alternatives (like Addy, SimpleLogin), no PGP support, custom rules, multi-domain / username aliases, etc. 
- Includes trackers on the homepage (Facebook like button!)
- Recent user reviews suggesting subscription cancellation issues
- Website seems dated nowadays, some of the pages not touched since 2010

---

### Affiliation
None

---

### Checklist
- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
