### PR TITLE
Moves ProtonMail (in mail aliases) to notable mentions

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1062,16 +1062,12 @@ categories:
           with paid plans (from $3/month) adding encrypted IMAP/POP3 mailboxes.
           Audited by Cure53 in 2026.
 
-      - name: ProtonMail
-        followWith: Professional plan or higher
-        url: https://protonmail.com/pricing
-        github: ProtonMail/WebClients
-        icon: https://proton.me/favicons/android-chrome-192x192.png
-        tosdrId: 491
-        openSource: true
-        description: |
-          If you already have ProtonMail's Professional (€8/month) or Visionary (€30/month) package,
-          then an implementation of this feature is available via the Catch-All Email feature.
+      notableMentions: >
+        Some full email providers include aliasing or catch-all addresses as a built-in
+        (usually premium) feature.
+        For example, [Proton](https://proton.me) (catch-all, plus hide-my-email aliases via Proton Pass),
+        [StartMail](https://www.startmail.com), [mailbox.org](https://mailbox.org) and
+        [Posteo](https://posteo.de) all offer this.
 
     ##################################
     ###### Mail Security Tools ######


### PR DESCRIPTION
### Type
Amendment

---

### Changes
Moves Proton out of Mail Forwarding section.
Adds a note in notable mentions to say some mail providers have aliasing as a premium feature.

---

### Supporting Material
N/A

---

### Affiliation
None.

---

### Checklist
- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

