### PR TITLE
Adds ShieldFive to Encrypted Cloud Storage

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3372,6 +3372,14 @@ categories:
           Has optional open-source client-side encryption, compatible with RClone. Can connect to other cloud services
           and MS Office. 10GB free, on ISO27001 servers (DE).
 
+      - name: ShieldFive
+        url: https://shieldfive.com
+        icon: https://shieldfive.com/apple-touch-icon.png
+        description: |
+          Zero-knowledge, end-to-end encrypted cloud storage; files encrypted on-device before upload.
+          Post-quantum by default (ML-KEM-1024, FIPS 203). EU-hosted, GDPR. Open-source crypto core
+          (Apache-2.0); closed-source apps, no external audit yet.
+
       notableMentions: |
         An alternative option, is to use a cloud computing provider, and implement
         the syncing functionality yourself, and encrypt data locally before


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds ShieldFive to the **Encrypted Cloud Storage** section (appended at the end, per CONTRIBUTING). ShieldFive is a zero-knowledge, end-to-end encrypted, EU-hosted cloud storage service with post-quantum (ML-KEM-1024, NIST FIPS 203) at-rest encryption by default. The entry is objective and states the drawbacks openly.

**On the open-source requirement (justification):** ShieldFive's cryptography library is open source and independently inspectable (`@shieldfive/crypto`, Apache-2.0), and the project publishes an internal security review. The web and mobile client apps are currently closed source, and there is no third-party audit yet — both stated plainly in the entry. This is comparable to other closed-source zero-knowledge providers already listed in this section (e.g. Tresorit, IceDrive). Happy to amend or withdraw if it doesn't meet the bar.

---

### Supporting Material
- Homepage: https://shieldfive.com
- Security posture + published internal review: https://shieldfive.com/security
- Open-source crypto library (Apache-2.0): https://github.com/shieldfive/crypto
- Privacy policy: https://shieldfive.com/privacy

---

### Affiliation
Yes — I am affiliated with ShieldFive and am submitting on behalf of the project. Disclosed for transparency.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)