### PR TITLE
Add pdfcevir under new Document Converters section

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3802,6 +3802,25 @@ categories:
         - Ruby: [Exif](https://github.com/tonytonyjan/exif) by @tonytonyjan
         - PHP: [Pel](https://github.com/pel/pel) by @mgeisler
 
+    ################################
+    ###### Document Converters #####
+    ################################
+    - name: Document Converters
+      intro: |
+        Converting or editing documents (such as PDFs) often means uploading them
+        to a third-party server, which can expose sensitive information contained
+        within contracts, ID scans, or personal records. Tools that process files
+        entirely on-device avoid this risk altogether.
+      services:
+      - name: pdfcevir
+        url: https://pdfcevir.vercel.app
+        github: trixterx102-byte/pdfcevir
+        openSource: true
+        description: |
+          Free PDF toolkit that runs 100% client-side in your browser -- merge, split,
+          compress, convert and watermark PDFs. Files never leave your device, no
+          server processing required.
+
     ##########################
     ###### Data Erasers ######
     ##########################

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3816,6 +3816,7 @@ categories:
         url: https://pdfcevir.vercel.app
         github: trixterx102-byte/pdfcevir
         openSource: true
+        icon: https://pdfcevir.vercel.app/icon-512.png
         description: |
           Free PDF toolkit that runs 100% client-side in your browser -- merge, split,
           compress, convert and watermark PDFs. Files never leave your device, no


### PR DESCRIPTION
I didn't find an existing category for document/PDF conversion tools, so I've proposed a new "Document Converters" section under Utilities. Happy to move this into a different/existing category if you'd prefer.

### Type
Addition

---

### Changes
Added a new "Document Converters" section under the Utilities category. Listed pdfcevir as the first entry — a free, open-source PDF toolkit (merge, split, compress, rotate, watermark, HEIC conversion, etc.) that runs entirely client-side in the browser, with no file uploads to any server.

---

### Supporting Material
- Live site: https://pdfcevir.vercel.app
- Source code (MIT licensed): https://github.com/trixterx102-byte/pdfcevir

---

### Affiliation
I am the developer/maintainer of pdfcevir, the project being added.

---

### Checklist
- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)