### PR TITLE
Adds VESmail to Email Security Tools

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1103,6 +1103,16 @@ categories:
         openSource: true
         acceptsCrypto: true
 
+      - name: VESmail
+        url: https://vesmail.email
+        icon: https://vesmail.email/favicon.ico
+        openSource: true
+        github: vesvault/VESmail
+        description: |
+          Self-hosted IMAP/SMTP proxy that end-to-end encrypts mail for any existing
+          email account, without changing clients or providers. Keys are recoverable
+          via the VESvault key repository, which the proxy depends on for key exchange.
+
       notableMentions: >
         If you are using ProtonMail, then the [ProtonMail Bridge](https://protonmail.com/bridge/thunderbird)
         enables you to sync & backup your emails to your own desktop mail client.


### PR DESCRIPTION

### Type
Addition

---

### Changes
Re-adding VESmail per your offer in #664 to revert the revert once the concerns were addressed. The automatic revert fails (the YAML has changed since), so this re-applies the same entry on current main; re-validated with lib/validate-awesome-privacy.py.

Since the reversal: signup fixed and tested, site content reworked (the stale app-store links are gone), security.txt + security headers added, and the README now has a quick-start (https://github.com/vesvault/VESmail#quick-start--the-cli).

Drafted with AI assistance; reviewed, tested and submitted by the maintainer.

---

### Supporting Material
Point-by-point response: https://github.com/Lissy93/awesome-privacy/pull/664#issuecomment-4921048277
Architecture write-up incl. what stays visible on the wire: https://dev.to/vesvaultjz/we-mitm-our-own-email-on-purpose-end-to-end-encryption-without-touching-the-mail-client-45np

---

### Affiliation
I'm the maintainer of VESmail.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

