### PR TITLE
Adds Vocalinux to Voice Assistants

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3615,6 +3615,24 @@ categories:
           No tracking, ads or data collection; all search and routing happen on-device. A community fork
           of Organic Maps, supporting driving, cycling and hiking.
 
+    - name: Accessibility
+      intro: |
+        Accessibility software like screen readers, dictation and voice input often runs
+        in the cloud, sending everything you say or read to a remote server. Privacy-respecting
+        alternatives keep this processing on your device, so your input never leaves it.
+      services:
+      - name: Vocalinux
+        description: |
+          Offline system-wide voice dictation for Linux (X11 and Wayland).
+          Uses local models (whisper.cpp, Whisper, or VOSK) so microphone
+          audio never leaves the device. Tray app with hotkeys; GPLv3.
+          Currently beta software.
+        url: https://vocalinux.com/
+        github: jatinkrmalik/vocalinux
+        icon: https://vocalinux.com/icon-192x192.png
+        followWith: Linux
+        openSource: true
+
   - name: Utilities
     sections:
     ##############################
@@ -4503,18 +4521,7 @@ categories:
         For that reason it is recommended not to have these devices in your house.
         The following are open source AI voice assistants, that aim to provide a
         human voice interface while also protecting your privacy and security
-      services:
-      - name: Vocalinux
-        description: |
-          Offline system-wide voice dictation for Linux (X11 and Wayland).
-          Uses local models (whisper.cpp, Whisper, or VOSK) so microphone
-          audio never leaves the device. Tray app with hotkeys; GPLv3.
-          Currently beta software.
-        url: https://vocalinux.com/
-        github: jatinkrmalik/vocalinux
-        icon: https://vocalinux.com/icon-192x192.png
-        followWith: Linux
-        openSource: true
+      services: []
 
       notableMentions: |
         [Mycroft](https://github.com/MycroftAI/mycroft-core) and [Kalliope](https://github.com/kalliope-project/kalliope) removed, as no longer active.

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4503,7 +4503,18 @@ categories:
         For that reason it is recommended not to have these devices in your house.
         The following are open source AI voice assistants, that aim to provide a
         human voice interface while also protecting your privacy and security
-      services: []
+      services:
+      - name: Vocalinux
+        description: |
+          Offline system-wide voice dictation for Linux (X11 and Wayland).
+          Uses local models (whisper.cpp, Whisper, or VOSK) so microphone
+          audio never leaves the device. Tray app with hotkeys; GPLv3.
+          Currently beta software.
+        url: https://vocalinux.com/
+        github: jatinkrmalik/vocalinux
+        icon: https://vocalinux.com/icon-192x192.png
+        followWith: Linux
+        openSource: true
 
       notableMentions: |
         [Mycroft](https://github.com/MycroftAI/mycroft-core) and [Kalliope](https://github.com/kalliope-project/kalliope) removed, as no longer active.


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds **Vocalinux** under Smart Home & IoT → Voice Assistants.

Vocalinux is free/open-source (GPLv3) offline system-wide voice dictation for Linux. Recognition runs locally via whisper.cpp, OpenAI Whisper, or VOSK, so microphone audio does not leave the machine. Useful as a privacy-preserving alternative to cloud voice typing / always-listening cloud assistants for desktop speech input.

**Note for reviewers:** The project is currently tagged beta (`v0.14.0-beta`) while actively maintained (regular releases, CI). Happy to move this to notableMentions if the stable-release rule should block a full listing.

---

### Supporting Material
- Website: https://vocalinux.com/
- Source: https://github.com/jatinkrmalik/vocalinux
- License: GPLv3
- Install docs: https://vocalinux.com/install/
- Privacy positioning: offline/local models, no account required

---

### Affiliation
Yes, I am the author/maintainer of Vocalinux (`jatinkrmalik/vocalinux`).

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
