### PR TITLE
Adds Tymeslot to Calendar

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3158,6 +3158,12 @@ categories:
           Note that CalDAV support is currently limited
           (see [#921](https://github.com/FossifyOrg/Calendar/issues/921)
 
+    ########################
+    ###### Scheduling ######
+    ########################
+    - name: Scheduling
+      alternativeTo: ['calendly', 'cal.com', 'doodle']
+      services:
       - name: Tymeslot
         url: https://tymeslot.app
         icon: https://tymeslot.app/images/brand/favicon-ca68e86a59d4a3ed9891fa9d036807e5.svg

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3158,6 +3158,16 @@ categories:
           Note that CalDAV support is currently limited
           (see [#921](https://github.com/FossifyOrg/Calendar/issues/921)
 
+      - name: Tymeslot
+        url: https://tymeslot.app
+        icon: https://tymeslot.app/images/brand/favicon-ca68e86a59d4a3ed9891fa9d036807e5.svg
+        github: Tymeslot/tymeslot
+        openSource: true
+        description: |
+          Open-source (AGPL-3.0), self-hostable scheduling and calendar platform. Guests book
+          without creating an account; hosts get a full calendar with two-way sync to Google,
+          Outlook and iCloud. A managed cloud plan is offered too, not self-hosted.
+
     ###############################
     ###### Task Management ######
     ##############################


### PR DESCRIPTION
### Type
Addition

---

### Changes

Adds Tymeslot to the Calendar section, alongside Proton Calendar, Nextcloud
Calendar and Fossify Calendar.

---

### Supporting Material

- Website: https://tymeslot.app
- Source code: https://github.com/Tymeslot/tymeslot
- Licence: AGPL-3.0 (OSI-approved, FSF-endorsed)

Note: I opened an earlier PR for this (#412) in March, which was closed because at the time
Tymeslot was licensed under the Elastic License 2.0 — not OSI open source. Tymeslot has since
been relicensed to AGPL-3.0 (shipped 2026-07-01), which resolves that. This PR states the
licence plainly rather than arguing the prior one.

---

### Affiliation

I am the author of Tymeslot.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories Contributor Covenant Code of Conduct