### PR TITLE
[Add] Zooid in Team Collaboration

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1323,6 +1323,18 @@ categories:
           conversations easier to follow than channel-only tools. Can be self-hosted, or
           used as a paid cloud service. The threading model takes some getting used to.
 
+      - name: Zooid
+        url: https://zooid.dev/
+        github: zooid-ai/zooid
+        icon: https://avatars.githubusercontent.com/u/262163976?v=4
+        openSource: true
+        description: |
+          Open source (MIT), self-hostable Slack alternative built on the Matrix protocol,
+          so conversations live on infrastructure you control rather than a vendor's servers.
+          Its distinguishing feature is that AI agents can join as first-class teammates,
+          with approval cards, tool calls and live plans; any ACP-compatible agent runs
+          sandboxed. Best suited to technical teams comfortable self-hosting.
+
       notableMentions: >
         Some chat platforms allow for cross-platform group chats, voice and video
         conferencing, but without the additional collaboration features.


### PR DESCRIPTION
This adds **Zooid** to the Communication → Team Collaboration section, alongside Rocket.Chat, Mattermost and Zulip.

Zooid is an open source (MIT), self-hostable Slack alternative built on the Matrix protocol, so conversations stay on infrastructure you own and control instead of a vendor's servers. What sets it apart is that AI agents can join as first-class teammates (approval cards, tool calls, live plans), with any ACP-compatible agent running sandboxed.

Disclosure: I'm the maker of Zooid. I've followed the schema and placed the entry at the bottom of the section per CONTRIBUTING; happy to adjust the description or any field to fit the list's conventions.
