### PR TITLE
Add OnDevicePDF in Online Tools

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1950,10 +1950,8 @@ categories:
           url: https://www.ondevicepdf.com
           icon: https://www.ondevicepdf.com/icon-192.png
           description: |
-            Free browser-based PDF tools with no accounts and offline PWA support. The security tools (password
-            protect, remove password, recover password and redact) are zero-egress by construction — a sealed
-            Content Security Policy (connect-src 'self') means the browser itself blocks any upload, which anyone
-            can verify in DevTools or via the live proof page at ondevicepdf.com/verify.
+            Free browser-based PDF tools. The security tools (protect, unlock, recover, redact) are zero-egress —
+            a sealed CSP (connect-src 'self') blocks all uploads, verifiable at ondevicepdf.com/verify.
           openSource: false
 
       wordOfWarning: >

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1946,6 +1946,16 @@ categories:
             A tool from Netcraft, for analysing what any given website is running, where it's located and information about its
             host, registrar, IP and SSL certificates.
 
+        - name: OnDevicePDF
+          url: https://www.ondevicepdf.com
+          icon: https://www.ondevicepdf.com/icon-192.png
+          description: |
+            Free browser-based PDF tools with no accounts and offline PWA support. The security tools (password
+            protect, remove password, recover password and redact) are zero-egress by construction — a sealed
+            Content Security Policy (connect-src 'self') means the browser itself blocks any upload, which anyone
+            can verify in DevTools or via the live proof page at ondevicepdf.com/verify.
+          openSource: false
+
       wordOfWarning: >
         Browsers are inherently insecure, be careful when uploading, or entering personal details.
 


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds OnDevicePDF to the Online Tools section — free browser-based PDF tools (no accounts, works offline as a PWA). The four security tools (password protect, remove password, recover forgotten password, redact) run under a sealed Content-Security-Policy (`connect-src 'self'`), so files cannot be uploaded — this is enforced by the browser and can be independently verified in DevTools. Entry sets `openSource: false` (source is not published); noting this upfront in case it should be routed to Notable Mentions per the criteria.

---

### Supporting Material
- Live verification page: https://www.ondevicepdf.com/verify
- Per-tool data handling: https://www.ondevicepdf.com/data-handling
- Privacy policy: https://www.ondevicepdf.com/privacy
- Chrome Web Store listing: (search "OnDevicePDF")

---

### Affiliation
I am the developer of OnDevicePDF.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
