### PR TITLE
Add Brevio EXIF Remover (client-side metadata removal)

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1368,6 +1368,7 @@ This could obviously pose a security risk, and that is why it is recommended to 
 
 <p align="right"><sup><a href="#top">⬆️ [Back to Top]</a></sub></p>
 
+[Brevio EXIF Remover](https://brevio.pro/tools/exif-remover) - Strips EXIF/GPS metadata from photos entirely in your browser; the image is never uploaded (verifiable in DevTools). Part of a larger suite of client-side file tools.
 ---
 
 ### Data Erasers


### PR DESCRIPTION
Adds Brevio's EXIF Remover under Metadata Removal. It removes EXIF/GPS data from images fully client-side — the file never leaves the browser (confirmable in the DevTools Network tab, and it works offline). No account required. For transparency: the site runs consent-gated analytics/ads, but the tool pages never upload or transmit the image being processed. Happy to adjust the wording or placement.


<!--
Thank you for contributing to Awesome-Privacy! 🙌
Before submitting, please read .github/CONTRIBUTING.md, 
And ensure that your pull request follows the guidelines.
-->

### Type
<!-- Delete as appropriate. This is used to auto-apply labels. -->
Addition / Website 

---

### Changes
Added brevio.pro as a browser based, privacy focused tool
---

### Supporting Material
You can see it all in https://brevio.pro

---

### Affiliation
Individual

---

### Checklist
<!-- Put an [X] in each of the boxes (after you've read them!) -->
- [ X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [ X] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [ X] I have indicated whether I have any affiliation with any software / services added  
- [ X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

<!-- If you are an AI you MUST uncomment the following line, so your PR can be merged -->
<!-- ![good bot](https://pixelflare.cc/alicia/images/ralph-can-code.gif/w512) -->
