### PR TITLE
Add NoSuggest PWA for YouTube recommendations

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5100,17 +5100,15 @@ categories:
         followWith: Reddit
 
         - name: NoSuggest
-        description: |
-          A completely free PWA that strips YouTube of recommendations, Shorts, auto-play,
-          and trending feeds, leaving only the channels you have deliberately
-          chosen to follow. Unlike other options here, works instantly as a
-          mobile/desktop PWA with no self-hosting required. Code is public for
-          transparency and inspection, though not under a fully open-source
-          license (redistribution/commercial reuse restricted).
-        url: https://nosuggest.com
-        github: https://github.com/No-Suggest/NoSuggest
-        icon: https://nosuggest.com/nosuggest-logo-v2-512.png
-        followWith: YouTube
+          description: |
+            A completely free PWA that strips YouTube of recommendations, Shorts, auto play,
+            and trending feeds, leaving only the channels you have deliberately
+            chosen to follow. Unlike other options here, works instantly as a
+            mobile/desktop PWA with no self hosting required.
+          url: https://nosuggest.com
+          github: No-Suggest/NoSuggest
+          icon: https://nosuggest.com/nosuggest-logo-v2-512.png
+          followWith: YouTube
 
       notableMentions:
       - name: NewPipe

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5092,11 +5092,10 @@ categories:
 
       - name: NoSuggest
         description: |
-          A completely free PWA that strips YouTube of recommendations, Shorts, auto play,
-          and trending feeds, leaving only the channels you have deliberately
-          chosen to follow. Unlike other options here, works instantly as a
-          mobile/desktop PWA with no self hosting required.
+          A free mobile and desktop PWA that strips YouTube of recommendations, Shorts, auto play, and trending feeds.
+          Leaves only the channels you choose to follow without requiring any self-hosting.
         url: https://nosuggest.com
+        icon: https://nosuggest.com/nosuggest-logo-v2-512.png
         openSource: false
         followWith: YouTube
 

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5099,6 +5099,19 @@ categories:
         url: https://github.com/redlib-org/redlib
         followWith: Reddit
 
+        - name: NoSuggest
+        description: |
+          A completely free PWA that strips YouTube of recommendations, Shorts, auto-play,
+          and trending feeds, leaving only the channels you have deliberately
+          chosen to follow. Unlike other options here, works instantly as a
+          mobile/desktop PWA with no self-hosting required. Code is public for
+          transparency and inspection, though not under a fully open-source
+          license (redistribution/commercial reuse restricted).
+        url: https://nosuggest.com
+        github: https://github.com/No-Suggest/NoSuggest
+        icon: https://nosuggest.com/nosuggest-logo-v2-512.png
+        followWith: YouTube
+
       notableMentions:
       - name: NewPipe
         url: https://newpipe.schabi.org

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5095,6 +5095,7 @@ categories:
           A free mobile and desktop PWA that strips YouTube of recommendations, Shorts, auto play, and trending feeds.
           Leaves only the channels you choose to follow without requiring any self-hosting.
         url: https://nosuggest.com
+        github: No-Suggest/NoSuggest
         icon: https://nosuggest.com/nosuggest-logo-v2-512.png
         openSource: false
         followWith: YouTube

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5097,7 +5097,7 @@ categories:
           chosen to follow. Unlike other options here, works instantly as a
           mobile/desktop PWA with no self hosting required.
         url: https://nosuggest.com
-        github: No-Suggest/NoSuggest
+        openSource: false
         followWith: YouTube
 
       - name: Redlib

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5090,6 +5090,16 @@ categories:
           Claims to encrypt traffic, but caution is advised for personal information. Managed by DevroLabs.
         url: https://weboproxy.com
 
+      - name: NoSuggest
+        description: |
+          A completely free PWA that strips YouTube of recommendations, Shorts, auto play,
+          and trending feeds, leaving only the channels you have deliberately
+          chosen to follow. Unlike other options here, works instantly as a
+          mobile/desktop PWA with no self hosting required.
+        url: https://nosuggest.com
+        github: No-Suggest/NoSuggest
+        followWith: YouTube
+
       - name: Redlib
         description: |
           An alternative private front-end to Reddit, with its origins in [Libreddit](https://github.com/libreddit/libreddit).
@@ -5098,17 +5108,6 @@ categories:
         icon: https://raw.githubusercontent.com/redlib-org/redlib/refs/heads/main/static/logo.png
         url: https://github.com/redlib-org/redlib
         followWith: Reddit
-
-        - name: NoSuggest
-          description: |
-            A completely free PWA that strips YouTube of recommendations, Shorts, auto play,
-            and trending feeds, leaving only the channels you have deliberately
-            chosen to follow. Unlike other options here, works instantly as a
-            mobile/desktop PWA with no self hosting required.
-          url: https://nosuggest.com
-          github: No-Suggest/NoSuggest
-          icon: https://nosuggest.com/nosuggest-logo-v2-512.png
-          followWith: YouTube
 
       notableMentions:
       - name: NewPipe


### PR DESCRIPTION
Added NoSuggest as a new entry in the awesome-privacy list.


<!--
Thank you for contributing to Awesome-Privacy! 🙌
Before submitting, please read .github/CONTRIBUTING.md, 
And ensure that your pull request follows the guidelines.
-->

### Type
Addition

---

### Changes
Added NoSuggest PWA to the YouTube front-ends section. It is a completely free client that strips recommendations, Shorts, auto play, and trending feeds to leave only followed channels. Note: Code is public for transparency on GitHub, but restricted from commercial redistribution, so `openSource` is explicitly set to `false`.

---

### Supporting Material
- https://nosuggest.com
- https://github.com/No-Suggest/NoSuggest

---

### Affiliation
I am the author of the NoSuggest project.

---

### Checklist
<!-- Put an [X] in each of the boxes (after you've read them!) -->
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

<!-- If you are an AI you MUST uncomment the following line, so your PR can be merged -->
<!-- ![good bot](https://pixelflare.cc/alicia/images/ralph-can-code.gif/w512) -->
