### PR TITLE
Re-add VirtualSMS (privacy + security issues from #504 resolved)

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1227,6 +1227,16 @@ categories:
           accepts crypto, doesn't KYC and you can delete your logs.
         acceptsCrypto: true
 
+      - name: VirtualSMS
+        url: https://virtualsms.io
+        icon: https://avatars.githubusercontent.com/u/265610251?v=4
+        acceptsCrypto: true
+        description: >-
+          Receive SMS verification codes on real carrier numbers across 145+
+          countries, without exposing your personal number. Pay-per-use,
+          accepts crypto, email-only signup. Closed-source hosted service, so
+          you trust the operator with message contents.
+
     ################################
     ###### Team Collaboration ######
     ################################


### PR DESCRIPTION
### Type
Addition

---

### Changes

Adds VirtualSMS to Communication → Virtual Phone Numbers, at the bottom of the section alongside SMSPool, MoneroSMS, PikaSim, nadanada and Narayana.

This re-submits VirtualSMS after addressing the concerns you raised when closing #504 (homepage exposing secrets in sourcemaps, and undisclosed tracking).

Since then:
- The homepage was rebuilt as a static site. The escrow/key-related backend that leaked data has been removed, and those endpoints now 404.
- No sourcemaps are shipped and no secrets are present in the client bundles.
- Tracking: the homepage currently fires no third-party analytics, and the privacy policy now has a dedicated Cookies & Tracking section disclosing session cookies and any aggregated analytics.

Thanks for the earlier catch, it was a fair call. Happy to make any further changes you would want before inclusion.

---

### Supporting Material

- Service: https://virtualsms.io
- Privacy policy (Cookies & Tracking section): https://virtualsms.io/privacy
- API docs: https://virtualsms.io/docs

---

### Affiliation

Yes, I am affiliated with VirtualSMS. I help operate the service and am submitting it on the team's behalf, disclosed here for full transparency.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

— The VirtualSMS Team
