### PR TITLE
Add PressImg image compressor to awesome-privacy.yml

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5313,7 +5313,13 @@ categories:
         description: |
           Web-based file conversion utility, which runs locally on your device using WebAssembly.
           Supports 250+ formats across images, audio, documents, and video.
-
+      - name: PressImg
+        url: https://pressimg.com
+        openSource: false
+        description: |
+          Browser-based image compressor and converter that runs entirely
+          on your device — no uploads, no account. Compresses and converts
+          JPG, PNG, WebP and AVIF with batch processing and ZIP export.
   - name: Creativity
     sections:
     - name: Image Editors


### PR DESCRIPTION
Added PressImg, a browser-based image compressor and converter, to the File Converters category.

### Type
Addition

### Changes
Adding PressImg — a client-side image compressor and converter (JPG, PNG, WebP, AVIF). Runs entirely in the browser via WebAssembly, so files are never uploaded. Supports batch processing and ZIP export. Not open source, and focused only on compression/conversion rather than full editing.

### Supporting Material
Homepage: https://pressimg.com
Privacy policy: https://pressimg.com/privacy

### Affiliation
I am the creator of PressImg.

### Checklist
- [x] I have read the Contributing guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories Contributor Covenant Code of Conduct
