### PR TITLE
Add REDACT privacy eraser for Windows

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3945,18 +3945,6 @@ categories:
         description: |
           C-based secure light-weight disk eraser, operated through the easy-to-use CLI or a GUI interface.
 
-      - name: REDACT
-        url: https://github.com/yonasabeselom/redact
-        github: yonasabeselom/redact
-        icon: https://avatars.githubusercontent.com/u/yonasabeselom
-        openSource: true
-        followWith: Windows
-        description: |
-          Open source Windows forensic artifact eraser. Removes 250+ traces
-          including AmCache, BAM, ShimCache, NTFS logs, Windows Recall,
-          Shell Bags and SRUM that BleachBit and CCleaner miss.
-          Supports 1–35 pass wipe modes.
-
       - name: shred
         url: https://www.gnu.org/software/coreutils/manual/html_node/shred-invocation.html
         git: https://git.savannah.gnu.org/cgit/coreutils.git
@@ -3982,6 +3970,18 @@ categories:
         description: |
           Proprietary, closed-source suite of forensic data tools for mobile. The data eraser allows for both Android and iOS to
           be fully wiped, through connecting them to a PC.
+
+      - name: REDACT
+        url: https://github.com/yonasabeselom/redact
+        github: yonasabeselom/redact
+        icon: https://avatars.githubusercontent.com/u/yonasabeselom
+        openSource: true
+        followWith: Windows
+        description: |
+          Open source Windows forensic artifact eraser. Removes 250+ traces
+          including AmCache, BAM, ShimCache, NTFS logs, Windows Recall,
+          Shell Bags and SRUM that BleachBit and CCleaner miss.
+          Supports 1–35 pass wipe modes.
 
       notableMentions: |
         There's no need to use a third-party tool. You can boot into a UNIX-based

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3945,6 +3945,17 @@ categories:
         description: |
           C-based secure light-weight disk eraser, operated through the easy-to-use CLI or a GUI interface.
 
+      - name: REDACT
+        url: https://github.com/yonasabeselom/redact
+        github: yonasabeselom/redact
+        openSource: true
+        followWith: Windows
+        description: |
+          Advanced forensic privacy eraser for Windows. Destroys 250+ system artifacts
+          that standard tools like BleachBit and CCleaner miss — including AmCache, BAM,
+          ShimCache, NTFS $UsnJrnl/$LogFile, Windows Recall, Shell Bags and SRUM.
+          Supports 1–35 pass cryptographic wipe modes with a native Windows 11 Fluent Dark UI.
+
       - name: shred
         url: https://www.gnu.org/software/coreutils/manual/html_node/shred-invocation.html
         git: https://git.savannah.gnu.org/cgit/coreutils.git

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3948,13 +3948,14 @@ categories:
       - name: REDACT
         url: https://github.com/yonasabeselom/redact
         github: yonasabeselom/redact
+        icon: https://avatars.githubusercontent.com/u/yonasabeselom
         openSource: true
         followWith: Windows
         description: |
-          Advanced forensic privacy eraser for Windows. Destroys 250+ system artifacts
-          that standard tools like BleachBit and CCleaner miss — including AmCache, BAM,
-          ShimCache, NTFS $UsnJrnl/$LogFile, Windows Recall, Shell Bags and SRUM.
-          Supports 1–35 pass cryptographic wipe modes with a native Windows 11 Fluent Dark UI.
+          Open source Windows forensic artifact eraser. Removes 250+ traces
+          including AmCache, BAM, ShimCache, NTFS logs, Windows Recall,
+          Shell Bags and SRUM that BleachBit and CCleaner miss.
+          Supports 1–35 pass wipe modes.
 
       - name: shred
         url: https://www.gnu.org/software/coreutils/manual/html_node/shred-invocation.html

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3974,7 +3974,7 @@ categories:
       - name: REDACT
         url: https://github.com/yonasabeselom/redact
         github: yonasabeselom/redact
-        icon: https://avatars.githubusercontent.com/u/yonasabeselom
+        icon: https://raw.githubusercontent.com/yonasabeselom/redact/main/logo.png
         openSource: true
         followWith: Windows
         description: |


### PR DESCRIPTION
Added REDACT, an advanced forensic privacy eraser for Windows, to the awesome-privacy.yml list.

### Type
Addition

---

### Changes
Added REDACT to the Data Erasers section. REDACT is an open source Windows tool that removes 250+ forensic artifacts — including AmCache, BAM, ShimCache, NTFS $UsnJrnl/$LogFile, Windows Recall, Shell Bags and SRUM — that standard privacy tools like BleachBit and CCleaner do not address. Supports 1–35 pass cryptographic wipe modes.

---

### Supporting Material
- GitHub: https://github.com/yonasabeselom/redact
- SourceForge: https://sourceforge.net/projects/redact/

---

### Affiliation
I am the author of REDACT.

---

### Checklist
- [X] I have read the Contributing guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [X] I have indicated whether I have any affiliation with any software / services added
- [X] I agree to follow the repositories Contributor Covenant Code of Conduct