### PR TITLE
Adds GUPT to Encrypted Messaging

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -707,6 +707,19 @@ categories:
           Note that homeservers can log IP addresses and metadata, and
           unrelayed 1:1 calls may reveal your IP to the other party.
 
+      - name: GUPT
+        url: https://gupt.app
+        openSource: true
+        github: besoeasy/gupt
+        icon: https://gupt.app/favicon.ico
+        description: |
+          A browser-native, serverless encrypted messenger and privacy suite built on
+          Nostr relays. No phone number, email, or account required — identity is a
+          cryptographic keypair. Features E2E encrypted chat, P2P WebRTC voice/video
+          calls, a password vault, and IPFS-based media storage. Entirely
+          client-side with no central server, making it a fully decentralized
+          alternative to WhatsApp, Signal, and Telegram.
+
       notableMentions:
         - name: Chat Secure
           url: https://chatsecure.org


### PR DESCRIPTION
### Addition

Adding GUPT to the Encrypted Messaging section.

### Changes

- Added GUPT — a browser-native, serverless encrypted messenger and privacy suite built on Nostr. No phone number, email, or account required. Features E2E encrypted chat, P2P WebRTC voice/video calls, a password vault, and IPFS-based media storage.

### Supporting Material

- Repository: https://github.com/besoeasy/gupt
- Website: https://gupt.app
- License: Open source
- Flathub: https://flathub.org/en/apps/com.besoeasy.gupt

### Affiliation

I am the author/maintainer of this project.

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)