### PR TITLE
Adds NexaTools P2P Transfer to file-drop

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1190,6 +1190,7 @@ It is recommended to encrypt files on your client machine, before syncing to the
 
 ### File Drop
 
+- **[<img src='https://icon.horse/icon/nexatools.in' width='14' alt='' /> NexaTools P2P Transfer](https://nexatools.in/utility-tools/file-transfer)** - A client-side WebRTC peer-to-peer file transfer web app. Transfers files directly between browsers without central cloud storage, but requires both devices to be online simultaneously.
 - **[<img src='https://icon.horse/icon/filesend.standardnotes.org' width='14' alt='' /> FileSend](https://filesend.standardnotes.org)** - Simple, encrypted file sharing, with a 500mb limit and 5-day retention. Files are secured with client-side AES-256 encryption and no IP address or device info is logged. Files are permanently deleted[…](https://awesome-privacy.xyz/productivity/file-drop/filesend "View full FileSend report") 
 - **[<img src='https://icon.horse/icon/onionshare.org' width='14' alt='' /> OnionShare](https://onionshare.org/)** - An open source tool that lets you securely and anonymously share a file of any size, via Tor servers. OnionShare does require installing, but the benefit is that your files are transferred directly to[…](https://awesome-privacy.xyz/productivity/file-drop/onionshare "View full OnionShare report") 
 


### PR DESCRIPTION
Added a new file sharing tool 'NexaTools P2P Transfer' to awesome-privacy.yml in the file-drop section.

### Type
Addition

---

### Changes
Added NexaTools P2P Transfer (WebRTC client-side peer-to-peer encrypted file sharing) to the file-drop section in awesome-privacy.yml.

---

### Supporting Material
- Website: https://nexatools.in/utility-tools/file-transfer
- Privacy Policy: https://nexatools.in/privacy.html

---

### Affiliation
Creator / Maintainer of NexaTools.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
