### PR TITLE
Add NexaTools P2P Transfer to awesome-privacy.yml

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1258,6 +1258,13 @@ categories:
           little technical experience is needed for users of the platform. Rocket.Chat's
           feature set is similar to Slack's, making it a good replacement for any team
           looking to have greater control over their data.
+          
+      - name: NexaTools P2P Transfer
+        url: https://nexatools.in/utility-tools/file-transfer
+        icon: https://nexatools.in/favicon.svg
+        description: |
+          A client-side WebRTC peer-to-peer file transfer web app. Transfers files directly
+          between browsers without central cloud storage, but requires both devices online.
 
       - name: RetroShare
         url: https://retroshare.cc/


### PR DESCRIPTION
Added a new file sharing tool 'NexaTools P2P Transfer' to awesome-privacy.yml in the file-drop section.

### Type
Addition

---

### Changes
Added NexaTools P2P Transfer (WebRTC client-side peer-to-peer encrypted file sharing) to the file-drop section in awesome-privacy.yml.

---

### Supporting Material
- Website: https://nexatools.in/utility-tools/file-transfer
- Privacy Policy: https://nexatools.in/privacy.html

---

### Affiliation
Creator / Maintainer of NexaTools.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
