### PR TITLE
Add Pixloc to Metadata Removal

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3875,6 +3875,19 @@ categories:
         description: |
           Native MacOS app, with drag 'n drop image optimization and meta data removal.
 
+      - name: Pixloc
+        url: https://pixloc.app
+        icon: https://pixloc.app/assets/icon-192.png
+        openSource: false
+        description: |
+          Web-based image converter that drops all EXIF metadata as a side effect of converting: GPS coordinates,
+          camera make and model, and timestamps do not survive the re-encode. Useful when you need a shareable copy
+          of a photo rather than a cleaned original.
+          Conversion runs entirely in the browser through the Canvas API, so no file is uploaded — verifiable by
+          disconnecting from the network, or watching the network tab, since the page keeps converting either way.
+          Handles HEIC, WebP, AVIF, PNG, JPG, BMP, GIF and SVG, in batches. No account, no watermark, works offline
+          as a PWA. Not open source, though the client-side claim is checkable from the browser.
+
       notableMentions: |
         It's possible (but slower) to do this without a third-party tool.
         For Windows, right click on a file, and go to: `Properties --> Details --> Remove Properties --> Remove from this File --> Select All --> OK`.


### PR DESCRIPTION
Adds [Pixloc](https://pixloc.app) under **Utilities → Metadata Removal**.

### Why this section

The three tools currently listed (ExifCleaner, ExifTool, ImageOptim) all require installing something. Pixloc covers the same need from a browser, which helps in the exact scenario this section's intro describes — someone about to share a photo that still carries its GPS coordinates.

It is a converter rather than a dedicated cleaner, and the entry says so: metadata is dropped **as a side effect** of re-encoding. That makes it suited to producing a shareable copy, not to cleaning an original in place.

### Verified, not assumed

I checked the claim rather than inferring it from the docs. A JPEG carrying `Make: Apple`, `Model: iPhone 15 Pro`, a timestamp and GPS coordinates went in; the converted file came out with **0 EXIF tags** — GPS included.

### Privacy claim

Conversion runs in the browser via the Canvas API, so no file is uploaded. Rather than asking anyone to take that on trust, the entry points at how to check it: disconnect from the network, or watch the network tab — the page keeps converting either way (it is an offline-capable PWA).

I set `openSource: false` deliberately. The source is not published, and in a privacy list that is worth stating plainly; what *can* be audited is the runtime behaviour, from the browser.

Happy to reword, trim the description, or move the entry to a different section if you would rather see it elsewhere.