### PR TITLE
Removes XPrivacyLua from mobile apps

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1635,17 +1635,6 @@ categories:
           use the camera to take a profile picture, but when you close the given app, those permissions
           will be revoked.
 
-      - name: XPrivacyLua
-        url: https://lua.xprivacy.eu/
-        icon: https://raw.githubusercontent.com/M66B/XPrivacyLua/master/app/src/main/ic_launcher-web.png
-        github: M66B/XPrivacyLua
-        description: |
-          Simple to use privacy manager for Android, that enables you to feed apps fake data when
-          they request intimate permissions. Solves the problem caused by apps malfunctioning when
-          you revoke permissions, and protects your real data by only sharing fake information. Enables
-          you to hide call log, calendar, SMS messages, location, installed apps, photos, clipboard,
-          network data plus more. And prevents access to camera, microphone, telemetry, GPS and other sensors.
-
       - name: SuperFreezZ
         url: https://superfreezz.gitlab.io/
         git: https://gitlab.com/SuperFreezZ/SuperFreezZ


### PR DESCRIPTION
### Type
Removal

---

### Changes
Removes XPrivacyLua, since it's no longer maintained. Repo is archived on GitHub.


---

### Supporting Material
N/A

---

### Affiliation
None

---

### Checklist
- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
