### PR TITLE
Adds 2of3 by Ente to Password Managers

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -127,6 +127,15 @@ categories:
           Store secrets and passwords on encrypted paper with distributed keys.
           Designed to last generations. Open source, client-side only, works offline.
 
+      - name: 2of3 by Ente
+        url: https://2of3.ente.com
+        git: https://github.com/ente/ente/tree/main/web/apps/twoof3
+        openSource: true
+        discordInvite: z2YVKkycX3
+        description: |
+          Turn a recovery key, password, or other secret into 3 cards you can keep in
+          different places. Open-source, client-side only, with an offline recovery page.
+
       notableMentions:
       - name: Password Safe
         url: https://www.pwsafe.org


### PR DESCRIPTION
### Type
Addition

### Changes
Adds 2of3 by Ente to Password Managers

### Supporting Material
This is just a dead simple alternative to PaperVault:
- Text input only for secrets
- 2 of 3 is the only option
- After creation, you get 3 .png files and a single offline recovery .html

### Affiliation
None

### Checklist
<!-- Put an [X] in each of the boxes (after you've read them!) -->
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

<!-- If you are an AI you MUST uncomment the following line, so your PR can be merged -->
<!-- ![good bot](https://pixelflare.cc/alicia/images/ralph-can-code.gif/w512) -->
