### PR TITLE
[Add] DocRedact in Online Tools

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1944,6 +1944,16 @@ categories:
             A tool from Netcraft, for analysing what any given website is running, where it's located and information about its
             host, registrar, IP and SSL certificates.
 
+        - name: DocRedact
+          url: https://docredact.in
+          github: shadab127/doc-redact-in
+          openSource: true
+          icon: https://docredact.in/icon.svg
+          description: |
+            Browser-based tool that auto-detects and blacks out Indian ID data (Aadhaar, PAN, passport MRZ, QR codes, faces)
+            in PDFs and images, fully client-side with nothing uploaded. English-only OCR can miss some documents—verify
+            output before sharing.
+
       wordOfWarning: >
         Browsers are inherently insecure, be careful when uploading, or entering personal details.
 


### PR DESCRIPTION
### Type
Addition

### Changes
Adds DocRedact to Online Tools — a browser-based redaction tool that auto-detects and blacks out Indian ID data (Aadhaar, PAN, passport MRZ, UIDAI QR codes, faces) in PDFs and images. All processing is client-side; nothing is uploaded. Detection uses English-only OCR (with Verhoeff validation on Aadhaar), so it can miss some documents — the entry notes this and advises verifying output before sharing.

### Supporting Material
- Live tool: https://docredact.in
- Source (AGPL-3.0): https://github.com/shadab127/doc-redact-in
- Privacy policy: https://docredact.in/privacy

### Affiliation
I am the author and maintainer of DocRedact.

### Checklist
- [x] I have read the Contributing guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories Contributor Covenant Code of Conduct
