### PR TITLE
Add Yap under Accessibility

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3674,6 +3674,18 @@ categories:
         followWith: Linux
         openSource: true
 
+      - name: Yap
+        description: |
+          On-device voice dictation for macOS. Press a hotkey, talk, and
+          the text is pasted into whatever field you were typing in. It uses
+          the built-in macOS 26 speech APIs, so there is no model to download
+          and no network code at all. MIT licensed.
+        url: https://github.com/FrigadeHQ/yap
+        github: FrigadeHQ/yap
+        icon: https://raw.githubusercontent.com/FrigadeHQ/yap/main/assets/yap-icon.png
+        followWith: Mac
+        openSource: true
+
   - name: Utilities
     sections:
     ##############################


### PR DESCRIPTION
Adds Yap to Productivity > Accessibility, alongside Vocalinux.

The section intro calls out dictation and voice input that should stay on your device, and right now it only lists Vocalinux for Linux. Yap is the macOS counterpart: an open source menu bar app for on-device voice dictation. You press a hotkey, talk, and the text is pasted into whatever field you were typing in. It uses the built-in macOS 26 speech APIs, so there is no model to download and no network code at all. MIT licensed.

https://github.com/FrigadeHQ/yap

Edited awesome-privacy.yml per the schema (name, description, url, github, icon, followWith: Mac, openSource). Validated that the file still parses.