### PR TITLE
Move Threema from avoid into notable mentions

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -743,7 +743,7 @@ categories:
       wordOfWarning: >
         Many messaging apps claim to be secure, but if they are not open source,
         then this cannot be verified - and they **should not be trusted**.
-        This applies to [Telegram](https://telegram.org), [Threema](https://threema.ch),
+        This applies to [Telegram](https://telegram.org),
         [Cypher](https://www.goldenfrog.com/cyphr), [Wickr](https://wickr.com/),
         [Silent Phone](https://www.silentcircle.com/products-and-solutions/silent-phone/)
         and [Viber](https://www.viber.com/), to name a few - these apps should not

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -740,6 +740,11 @@ categories:
             defined in [EFAIL](https://efail.de/), so although it still considered
             secure for general purpose use, for general chat, it may be better to
             use an encrypted messaging or email app instead.
+        - name: Threema
+          url: https://threema.ch
+          description: >
+            A paid, business-focused Swiss messenger. The apps are open source,
+            but the server is proprietary.
       wordOfWarning: >
         Many messaging apps claim to be secure, but if they are not open source,
         then this cannot be verified - and they **should not be trusted**.


### PR DESCRIPTION
### Type
Amendment

---

### Changes
Removes Threema from the warning section of Messaging.
Adds Threema to the notable mentions section of messaging
Fixes #133

---

### Supporting Material

Threema was initially on the avoid list, since it was closed source at the time I'd written this. But now, since 2020 Threema clients are indeed open source. (the server is not)

I've reviewed Threema, and have moved it to the notable mentions section.
They have a strong usecase, specifically for enterprise. However is less suited to normal/free users, not fully open source, and has had some controversy in the past. Might remove this if their direction changes since the acquisition. 

The good:
- 🟢 Security audited
  -  All apps in 2020: [report](https://threema.com/assets/6-resources/audits/2020_cure53_audit_mobile_apps.pdf)
  - Desktop app in 2024: [report](https://cure53.de/pentest-report_threema-desktop.pdf)
  - Ibex protocol 2023: [report](https://threema.com/assets/6-resources/audits/security_analysis_ibex_2023.pdf)
- 🟢 Published transparency reports
  - https://threema.com/en/transparency-report
- 🟢 They've won court cases to avoid being required to store metadata ([link](https://newsworthy-news.com/2021/05/28/threema-the-european-rival-to-signal-wins-pivotal-privacy-battle-in-swiss-court/))
- 🟢 Client apps open source (AGPLv3)
  - https://github.com/threema-ch
- 🟢 Reproducible builds. Plus signing, attestation, checksums, generally good hygine, and no propritry libs
- 🟢 No phone number, email or personal details required
- 🟢 Can be purchased and downloaded fully anonymously, outside google, with crypto
- 🟢 Can be self-hosted for enterprises, via their [on prem offering](https://threema.com/en/products/onprem)
- 🟢 Server-blind group chats, multi-device, forward secrecy
- 🟢 Switzerland


The warnings:
- 🟡 They had a pretty nasty vulnerability found in 2023, which Threema downplayed
  - https://www.usenix.org/system/files/usenixsecurity23-paterson.pdf (this is a really interesting read)
- 🟡 Previously had some "interesting" crypto designs (interesting meaning insecure) - all fixed now
  - https://soatok.blog/2021/11/05/threema-three-strikes-youre-out/ (another good read)
- 🟡 Uses it's own custom crypto protocol
  - Crypto whitepaper: https://threema.com/assets/documents/threema-cryptography-whitepaper.pdf
- 🟡 1:1 voice calls reveal your IP to the peer, but this can be prevented by enabling relay
- 🟡 Primarily a paid, business-focused app

The bad:
- 🔴 Server is closed source
- 🔴 They've been acquired by private equity
  - https://comitiscapital.com/news/comitis-capital-announces-the-acquisition-of-threema

---

### Affiliation
None

---

### Checklist
- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
