### PR TITLE
Add RegexPilot to Developer Tools

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4569,6 +4569,18 @@ categories:
           with your name, email and commit metadata stripped, optionally over Tor. Anonymity
           isn't perfect, and the hosted service has had abuse-related downtime.
 
+      - name: RegexPilot
+        url: https://regexpilot.com/
+        icon: https://regexpilot.com/favicon-32.png
+        openSource: false
+        description: |
+          macOS regex editor that runs entirely on-device, as an alternative to pasting
+          patterns and sample text into an online tester. Test data for a regex is often
+          real data: emails, logs, identifiers. RegexPilot bundles 21 native engines and
+          evaluates locally, with no accounts, no telemetry and no cloud calls. Optional
+          AI generation uses your own API key, or a fully local model via Ollama or
+          LM Studio. Proprietary, with a free tier.
+
   - name: Smart Home & IoT
     sections:
     - name: Voice Assistants


### PR DESCRIPTION
Adds RegexPilot under **Development → Developer Tools**, alongside DevToys and Bruno.

**Privacy relevance:** the usual way to test a regex is to paste it, plus sample text, into an online tester. That sample text is frequently real data — email addresses, log lines, identifiers, sometimes credentials. RegexPilot evaluates everything locally against 21 bundled native engines, so the data never leaves the machine. Same argument DevToys is listed for, applied to regex.

- No accounts, no telemetry, no cloud calls
- AI generation is opt-in and uses your own API key, or a fully local model via Ollama, LM Studio or llama.cpp
- Voice dictation runs on-device via a bundled Whisper model
- macOS 14+, universal binary, signed and notarized

Marked `openSource: false` — it is proprietary, with a free tier. Flagging that explicitly since most entries here are open source; happy for it to be dropped if closed-source tools are not wanted in this section.

YAML validated. Disclosure: I am the developer.