### PR TITLE
Add DarkVPS to Cloud Hosting

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2912,7 +2912,7 @@ categories:
           hosting of open-source apps (Grafana, Matomo, Vaultwarden, etc.) and S3-compatible object
           storage. GDPR-native, ISO 27001 compliant, with no vendor lock-in.
 
-     - name: DarkVPS
+      - name: DarkVPS
         url: https://darkvps.pro
         icon: https://www.darkvps.pro/navlogo.webp
         acceptsCrypto: true
@@ -2920,7 +2920,7 @@ categories:
           Offshore, anonymous VPS and bare-metal hosting based in Bulgaria, running on
           owned hardware. No KYC, no logs, DMCA ignored, with 30-second deployment.
           Accepts crypto payments (Bitcoin, Monero, USDT, Ethereum, Litecoin, Tron).
-          IP geolocation in Bulgaria, Switzerland, Iceland or Netherlands. Pricing from €12/month.
+          IP geolocation in Bulgaria, Switzerland, Iceland or Netherlands.
 
       notableMentions: |
         See also: [1984](https://www.1984.is) based in Iceland.

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2912,7 +2912,7 @@ categories:
           hosting of open-source apps (Grafana, Matomo, Vaultwarden, etc.) and S3-compatible object
           storage. GDPR-native, ISO 27001 compliant, with no vendor lock-in.
 
-       - name: DarkVPS
+     - name: DarkVPS
         url: https://darkvps.pro
         icon: https://www.darkvps.pro/navlogo.webp
         acceptsCrypto: true

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2912,6 +2912,16 @@ categories:
           hosting of open-source apps (Grafana, Matomo, Vaultwarden, etc.) and S3-compatible object
           storage. GDPR-native, ISO 27001 compliant, with no vendor lock-in.
 
+       - name: DarkVPS
+        url: https://darkvps.pro
+        icon: https://www.darkvps.pro/navlogo.webp
+        acceptsCrypto: true
+        description: |
+          Offshore, anonymous VPS and bare-metal hosting based in Bulgaria, running on
+          owned hardware. No KYC, no logs, DMCA ignored, with 30-second deployment.
+          Accepts crypto payments (Bitcoin, Monero, USDT, Ethereum, Litecoin, Tron).
+          IP geolocation in Bulgaria, Switzerland, Iceland or Netherlands. Pricing from €12/month.
+
       notableMentions: |
         See also: [1984](https://www.1984.is) based in Iceland.
         [Shinjiru](http://shinjiru.com?a_aid=5e401db24a3a4), which offers off-shore dedicated servers.


### PR DESCRIPTION
Adds DarkVPS, an offshore and anonymous VPS and bare-metal hosting provider based in Bulgaria, running on owned hardware. No KYC, no logs, DMCA ignored, 30-second deployment. Accepts crypto payments (BTC, XMR, USDT, ETH, LTC, TRX). Listed under Networking > Cloud Hosting.

### Type
Addition

### Changes
Adds DarkVPS under Networking > Cloud Hosting.

### Supporting Material
- Website: https://darkvps.pro
- Privacy Policy: https://www.darkvps.pro/privacy

### Affiliation
I am affiliated with DarkVPS.

### Checklist
- [X] I have read the Contributing guide
- [X] I have performed a self-review
- [X] I have indicated my affiliation
- [X] I agree to follow the Code of Conduct