### PR TITLE
Adds Glyph to Digital Notes

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3126,6 +3126,7 @@ categories:
         github: SidhuK/Glyph
         followWith: MacOS
         openSource: true
+        icon: https://glyphformac.com/favicon.ico
         description: |
           Offline-first Markdown notes app for macOS with local file storage, search, tasks, and optional AI tools.
           AGPL-3.0 source is available to build yourself; official builds are a paid one-time purchase after a 7-day trial.

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3121,6 +3121,15 @@ categories:
           A free, open-source note-taking application built with Qt, focused on providing a pleasant Markdown
           editing experience. It manages notes directly as plain text files on your local system.
 
+      - name: Glyph
+        url: https://glyphformac.com/
+        github: SidhuK/Glyph
+        followWith: MacOS
+        openSource: true
+        description: |
+          Offline-first Markdown notes app for macOS with local file storage, search, tasks, and optional AI tools.
+          AGPL-3.0 source is available to build yourself; official builds are a paid one-time purchase after a 7-day trial.
+
       notableMentions: |
         If you are already tied into Evernote, One Note etc, then [SafeRoom](https://www.getsaferoom.com)
         is a utility that encrypts your entire notebook, before it is uploaded to the cloud.


### PR DESCRIPTION
<!--
Thank you for contributing to Awesome-Privacy! 🙌
Before submitting, please read .github/CONTRIBUTING.md,
And ensure that your pull request follows the guidelines.
-->

### Type
Addition

---

### Changes
Adds Glyph to Digital Notes.

Glyph is an offline-first Markdown notes app for macOS with local file storage, search, tasks, and optional AI tools. The source is AGPL-3.0 and can be built by users; official builds are a paid one-time purchase after a 7-day trial. The entry does not make an unverified claim about tracker behavior.

---

### Supporting Material
- Website: [glyphformac.com](https://glyphformac.com/)
- Source: [github.com/SidhuK/Glyph](https://github.com/SidhuK/Glyph) (AGPL-3.0)
- The repository has public stable releases, with the earliest currently listed as `v0.1.68` on 2026-03-28.

---

### Affiliation
I am the creator and maintainer of Glyph.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

![good bot](https://pixelflare.cc/alicia/images/ralph-can-code.gif/w512)
