### PR TITLE
Adds norito Remove Metadata to Online Tools

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1978,6 +1978,15 @@ categories:
           description: |
             A tool from Netcraft, for analysing what any given website is running, where it's located and information about its
             host, registrar, IP and SSL certificates.
+            
+        - name: norito Remove Metadata
+          url: https://norito.in/remove-metadata.html
+          icon: https://norito.in/assets/apple-touch-icon.png
+          github: ShubhMisaki/norito-devtoolbox
+          openSource: true
+          description: |
+            Strips EXIF, GPS location and camera metadata from a photo entirely in the browser, so the
+            image never leaves the device. JPEG re-encoding causes a small quality loss; PNG stays lossless.
 
       wordOfWarning: >
         Browsers are inherently insecure, be careful when uploading, or entering personal details.


### PR DESCRIPTION
Adding norito's Remove Metadata tool to the Online Tools section. It strips EXIF, GPS, and camera metadata from a photo entirely client-side (no upload), similar in purpose to the existing EXIF Remove entry but with the source image never leaving the device.

### Type

Addition

### Changes

Adds one new service entry, norito Remove Metadata, to the Online Tools section, after the existing Site Report entry. No other lines changed.

### Supporting Material

Tool: https://norito.in/remove-metadata.html
Source: https://github.com/ShubhMisaki/norito-devtoolbox (MIT licensed)

### Affiliation

I am the developer of norito. Disclosing this per the contributing guidelines.

### Checklist

- [x] I have read the Contributing guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories Contributor Covenant Code of Conduct