### PR TITLE
Removes Qwant from search engines

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -567,18 +567,6 @@ categories:
           and a [no Javascript version](https://duckduckgo.com/html/).
           Note: Search data is primarily sourced from Bing, and DDG operates from within the US.
 
-      - name: Qwant
-        url: https://www.qwant.com
-        icon: https://avatars.githubusercontent.com/u/1692504
-        iosApp: https://apps.apple.com/us/app/qwant-private-search/id924470452
-        androidApp: com.qwant.liberty
-        subreddit:  Qwant
-        tosdrId: 527
-        description: |
-          French service that aggregates Bings results, with its own results. Qwant doesn't
-          plant any cookies, nor have any trackers or third-party advertising. It returns
-          non-biased search results, with no promotions. Qwant has a unique, but nice UI.
-
       - name: Startpage
         url: https://www.startpage.com
         icon: https://www.startpage.com/favicon.ico
@@ -641,6 +629,13 @@ categories:
           It is EU-based and 100% open source. It allows customization via Goggles.
 
       notableMentions:
+      - name: Qwant
+        url: https://www.qwant.com
+        description: >
+          French search engine, running on Bing results and the new European Search Perspective.
+          Contains contextual, non-tracking ads.
+          Privacy policy is out-dated, and Qwant does track users despite claiming not to.
+          See [full review](https://github.com/Lissy93/awesome-privacy/issues/45) for more info.
       - name: MetaGear
         url: https://metager.org
       - name: YaCy


### PR DESCRIPTION
### Type
Removal

---

### Changes
Removes Qwant from search engines. See https://github.com/lissy93/awesome-privacy/issues/45#issuecomment-5196955098

I will leave this open for a few days, and wait for comment on #45.
I've also reached out to Qwant, because these may just be genuine "mistakes" without any bad intent (but I doubt they will reply to little old me!)

Personally, I'd be ok to keep Qwant listed WITH warnings, if they were transparent about what data was collected, processed, stored, shared, etc. and their opt-in/out mechanisms were working. (mostly just because there's very few privacy-resepcting search engines). But I will not keep anything listed if it is dishonest / misleading or blatantly abuses user data and trust 🙅‍♀️

---

### Supporting Material

- Privacy policy is out-dated. Doesn't disclose all third-parties or tracking
- Cookie mechanism is broken in some regions (like UK)
- Declining cookies, sending `Sec-GPC: 1` or opting out of tracking is not respected
- Cross-domain identifier sharing is present (with Qwant's sister company)
- Children (under 16s) using Qwant Junior are heavily tracked, without proper documentation
- Homepage marketing is misleading, so trust is now reduced (we don't know what happens on the backend)

^^ all the above outlined in more detail [in the issue thread](https://github.com/lissy93/awesome-privacy/issues/45#issuecomment-5196955098)

---

### Affiliation
None

---

### Checklist
- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

