### PR TITLE
Adds No Bloat PDF to Metadata Removal

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3899,6 +3899,16 @@ categories:
         description: |
           Native MacOS app, with drag 'n drop image optimization and meta data removal.
 
+      - name: No Bloat PDF
+        url: https://www.nobloatpdf.com
+        github: bgalvan1277/NoBloatPDF
+        followWith: Windows & MacOS
+        icon: https://www.nobloatpdf.com/assets/icon.png
+        description: |
+          Rebuilds a PDF from scratch so author name, metadata, embedded scripts and prior saved
+          revisions are removed rather than hidden. Runs locally with no network calls. Handles
+          PDFs only, not images, and has no Linux build.
+
       notableMentions: |
         It's possible (but slower) to do this without a third-party tool.
         For Windows, right click on a file, and go to: `Properties --> Details --> Remove Properties --> Remove from this File --> Select All --> OK`.


### PR DESCRIPTION
### What

Adds [No Bloat PDF](https://www.nobloatpdf.com) to **Utilities > Metadata Removal**.

### Why this section

The section currently covers image and EXIF metadata (ExifCleaner, ExifTool, ImageOptim). PDF document metadata is a distinct and commonly overlooked leak: author name, title, creating application, timestamps, XMP packets, embedded JavaScript, and prior incremental-save revisions that remain recoverable inside the file after an edit.

No Bloat PDF has a Sanitize Document tool that rebuilds the file from scratch through the renderer rather than stripping fields in place, so removed content does not survive as a recoverable earlier revision. It runs locally and the app makes no network calls at all.

### Disclosure

I am affiliated with this project, submitting on behalf of the developer.

### Notes on the entry

- Description is 219 characters, within the 50 to 250 requirement
- It names the real limitations as well: PDFs only rather than images, and no Linux build
- Placed alphabetically after ImageOptim
- Edited `awesome-privacy.yml` only, not the generated README
- Free and open source, MIT. Windows installer is signed with a Microsoft-verified publisher identity; macOS builds are Developer ID signed and notarized