### PR TITLE
Adds MindMapVault to Digital Notes

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3133,6 +3133,17 @@ categories:
           A free, open-source note-taking application built with Qt, focused on providing a pleasant Markdown
           editing experience. It manages notes directly as plain text files on your local system.
 
+      - name: MindMapVault
+        url: https://www.mindmapvault.com
+        github: mindmapvault/mindmapvault-foss
+        followWith: Windows, Mac OS, Linux
+        openSource: true
+        icon: https://www.mindmapvault.com/apple-touch-icon.png
+        description: |
+          Mind mapping and notes with client-side encryption. The FOSS desktop build runs fully offline
+          with no account or server, but it is local-only, with no sync between devices and no mobile
+          apps.
+
       notableMentions: |
         If you are already tied into Evernote, One Note etc, then [SafeRoom](https://www.getsaferoom.com)
         is a utility that encrypts your entire notebook, before it is uploaded to the cloud.


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds MindMapVault to Productivity → Digital Notes, at the bottom of the section.

A mind mapping and notes application with client-side encryption. The FOSS
desktop build is local-only: it runs without an account or a server, and keeps
data on the device. That is also its main limitation — the FOSS build has no
sync between devices, and there are no mobile apps. A separate self-hosted or
hosted edition exists for sync; the entry describes the FOSS build.

Only `awesome-privacy.yml` is edited. `make validate` passes
(13 categories, 91 sections, 390 services).

---

### Supporting Material

- Source (FOSS desktop, MIT): https://github.com/mindmapvault/mindmapvault-foss
- Latest release with SHA-256 checksums for Windows, macOS and Linux:
  https://github.com/mindmapvault/mindmapvault-foss/releases/tag/v0.3.33
- Security policy and threat model:
  https://github.com/mindmapvault/mindmapvault-foss/blob/main/SECURITY.md
- Security whitepaper: https://www.mindmapvault.com/security-whitepaper/
- Privacy notice: https://www.mindmapvault.com/privacy/
- Homepage: https://www.mindmapvault.com

Points a reviewer may want to weigh:

- Not independently security audited, so `securityAudited` is omitted.
- No ToS;DR analysis exists, so `tosdrId` is omitted.
- The macOS build is a universal binary, but it is not signed with an Apple
  Developer ID and is not notarized, so Gatekeeper blocks it on first launch.
  The workaround is documented in the project README.
- No telemetry in the desktop app, and no analytics on the website.

---

### Affiliation

I am the author of MindMapVault and maintain the project. This is a
self-submission.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

<!-- If you are an AI you MUST uncomment the following line, so your PR can be merged -->
<!-- ![good bot](https://pixelflare.cc/alicia/images/ralph-can-code.gif/w512) -->
