### PR TITLE
[ADDITION] Warren in Virtual Private Networks

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2061,6 +2061,19 @@ categories:
           WireGuard and AmneziaWG protocols, no-logs policy, REST API for developers. No
           subscriptions or credit cards.
 
+      - name: Warren
+        url: https://warren.ro
+        github: WarrenBrowse/warren-app
+        openSource: true
+        securityAudited: false
+        acceptsCrypto: true
+        icon: https://warren.ro/icon-192.png
+        description: |
+          Romania-based no-logs VPN running over QUIC, so tunnel traffic is hard to tell apart
+          from ordinary HTTPS browsing. Account-free: access keys derive from a local wallet,
+          no email asked. Open source apps (AGPL-3.0), port forwarding included, pays with card,
+          Lightning or Monero. Not independently audited yet.
+
       - name: Windscribe
         url: https://windscribe.com
         github: Windscribe/Desktop-App

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2061,19 +2061,6 @@ categories:
           WireGuard and AmneziaWG protocols, no-logs policy, REST API for developers. No
           subscriptions or credit cards.
 
-      - name: Warren
-        url: https://warren.ro
-        github: WarrenBrowse/warren-app
-        openSource: true
-        securityAudited: false
-        acceptsCrypto: true
-        icon: https://warren.ro/icon-192.png
-        description: |
-          Romania-based no-logs VPN running over QUIC, so tunnel traffic is hard to tell apart
-          from ordinary HTTPS browsing. Account-free: access keys derive from a local wallet,
-          no email asked. Open source apps (AGPL-3.0), port forwarding included, pays with card,
-          Lightning or Monero. Not independently audited yet.
-
       - name: Windscribe
         url: https://windscribe.com
         github: Windscribe/Desktop-App
@@ -2087,6 +2074,18 @@ categories:
           An audited and court-proven VPN with a free 10GB plan, in-RAM servers, browser extensions
           and open source WireGuard/IKEv2/OpenVPN clients. Supports split tunneling,
           customizable DNS blocking, MAC spoofing, decoy traffic and censorship circumvention.
+
+      - name: Warren
+        url: https://warren.ro
+        github: WarrenBrowse/warren-app
+        openSource: true
+        securityAudited: false
+        acceptsCrypto: true
+        icon: https://warren.ro/icon-192.png
+        description: |
+          Romania-based no-logs VPN over QUIC, hard to tell apart from ordinary HTTPS.
+          No account or email: keys derive from a local wallet. Open source (AGPL-3.0),
+          port forwarding included, card, Lightning or Monero payment. Not yet independently audited.
 
       wordOfWarning: |
         - *A VPN does not make you anonymous - it merely changes your public IP address to that of your VPN provider, instead of your ISP. Your browsing session can still be linked back to your real identity either through your system details (such as user agent, screen resolution even typing patterns), cookies / session storage, or by the identifiable data that you enter. [Read more about fingerprinting](https://pixelprivacy.com/resources/browser-fingerprinting/)*


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds Warren to the Virtual Private Networks category: a Romania-based no-logs VPN over QUIC, account-free (keys derive from a locally generated wallet, no email), open source, port forwarding included, card, Lightning or Monero payment. securityAudited is set to false: no independent audit yet (planned).

---

### Supporting Material
- Website: https://warren.ro
- Source: https://github.com/WarrenBrowse (engine and SDKs AGPL-3.0, apps GPL-3.0)
- Privacy policy: https://warren.ro/fr/confidentialite

---

### Affiliation
I am the founder of Warren.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)