### PR TITLE
Adds JuicySMS to Virtual Phone Numbers

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1248,6 +1248,16 @@ categories:
           accepts crypto, doesn't KYC and you can delete your logs.
         acceptsCrypto: true
 
+      - name: JuicySMS
+        url: https://juicysms.com
+        icon: https://juicysms.com/web-app-manifest-512x512.png
+        acceptsCrypto: true
+        description: >-
+          Temporary numbers for receiving SMS verification codes, on carrier SIMs
+          rather than internet-routed lines. Only charged when a code arrives.
+          Requires an account and email, and coverage is limited to the US, UK,
+          Netherlands and Philippines.
+
     ################################
     ###### Team Collaboration ######
     ################################


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds JuicySMS to Virtual Phone Numbers. It sells temporary numbers for receiving
verification codes, on real carrier SIMs rather than internet-routed lines, which
is why they're accepted on platforms that refuse virtual numbers.

The description notes the two limitations that matter for this list: an account
and email address are required, and coverage is only four countries.

---

### Supporting Material
- Homepage: https://juicysms.com
- Privacy policy: https://juicysms.com/privacy-policy
- Terms: https://juicysms.com/terms
- API docs: https://juicysms.com/api
- Reviews: https://www.trustpilot.com/review/juicysms.com

Running since 2019. Accounts can be deleted from the account page. Payment by
card, European methods via Mollie, AliPay, WeChat Pay, or crypto including Monero.

---

### Affiliation
I run JuicySMS, so I'm submitting my own service. Happy to have it judged on that
basis or dropped if you'd rather not list operator submissions.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
