### PR TITLE
Add Zen Passwords to Password Managers notable mentions

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -170,7 +170,6 @@ categories:
           and they have a solid reputation for transparently disclosing and fixing vulnerabilities
       - name: Zen Passwords
         url: https://www.zenproducts.ai/apps/zen-passwords
-        iosApp: https://apps.apple.com/us/app/zen-passwords/id6761246936
         description: >
           (proprietary) Private password manager for iPhone, iPad, and Mac.
           Vault is encrypted on device before any optional sync; sync (when enabled)

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -168,6 +168,15 @@ categories:
           is not fully open source, but they do regularly publish results of their
           independent [security audits](https://support.1password.com/security-assessments),
           and they have a solid reputation for transparently disclosing and fixing vulnerabilities
+      - name: Zen Passwords
+        url: https://www.zenproducts.ai/apps/zen-passwords
+        iosApp: https://apps.apple.com/us/app/zen-passwords/id6761246936
+        description: >
+          (proprietary) Private password manager for iPhone, iPad, and Mac.
+          Vault is encrypted on device before any optional sync; sync (when enabled)
+          uses the user's own Apple ID / iCloud, and the vendor does not hold the
+          master password. Free tier available; Premium via Apple In-App Purchase.
+          Privacy policy: https://www.zenproducts.ai/apps/zen-passwords/privacy
       furtherInfo: >
         **Other Open Source PM**: [Buttercup](https://buttercup.pw), [Clipperz](https://clipperz.is),
         [Pass](https://www.passwordstore.org), [Padloc](https://padloc.app), [TeamPass](https://teampass.net),


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds Zen Passwords under Essentials → Password Managers → notableMentions (proprietary, same section as 1Password).

Factual notes only: on-device vault encryption before optional sync; optional sync via the user's Apple ID / iCloud; vendor does not hold the master password; free tier + Apple IAP Premium.

Edited `awesome-privacy.yml` only (not the generated README).

---

### Supporting Material
- Product: https://www.zenproducts.ai/apps/zen-passwords
- Privacy policy: https://www.zenproducts.ai/apps/zen-passwords/privacy
- App Store: https://apps.apple.com/us/app/zen-passwords/id6761246936

---

### Affiliation
I am the developer / publisher of Zen Passwords (ZENPRODUCTS).

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

![good bot](https://pixelflare.cc/alicia/images/ralph-can-code.gif/w512)

Made with [Cursor](https://cursor.com)