### PR TITLE
Adds Atomic Agent to Developer Tools

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4592,6 +4592,17 @@ categories:
           with your name, email and commit metadata stripped, optionally over Tor. Anonymity
           isn't perfect, and the hosted service has had abuse-related downtime.
 
+      - name: Atomic Agent
+        url: https://atomicagent.io
+        github: AtomicBot-ai/atomic-agent
+        icon: https://avatars.githubusercontent.com/u/259533419?s=200&v=4
+        openSource: true
+        discordInvite: https://discord.gg/Us7qXtDGw
+        description: |
+          CLI and TUI coding assistant that runs open-weight models entirely on your machine
+          via a llama.cpp fork, with no account or API key required. Anonymous usage analytics
+          and crash reporting are on by default, though both can be disabled.
+
   - name: Smart Home & IoT
     sections:
     - name: Voice Assistants


### PR DESCRIPTION
Hi! I'm the CPO of Atomic Agent. Thanks for maintaining this list, it's a genuinely useful resource and our team would be thrilled to be included. I've tried to follow the contributing guide closely, and I'm happy to adjust anything that doesn't fit.

### Type

Addition

---

### Changes

Adds **Atomic Agent** to the end of the *Development > Developer Tools* section in `awesome-privacy.yml`. The README was not edited, since it is auto-generated.

Atomic Agent is a local-first CLI and TUI coding assistant. It runs open-weight models entirely on your machine through a llama.cpp fork, and needs no account or API key to install or run. It ships 56 built-in tools (browser, filesystem, git, memory, vision), supports MCP, has a five-layer local memory system, and runs on macOS, Linux and Windows. The TUI is built on React and ink.

Two things I want to flag up front rather than have you find them in review:

1. **Analytics is on by default.** Anonymous usage analytics sends provider and model names, a random per-install id, and turn-shape numbers such as latency and step count. It never sends message content, file paths, or tool arguments. Crash reports go to Sentry on the same switch. Both can be turned off with `/privacy analytics off` in the TUI, or `"analytics": { "enabled": false }` in `config.json`, applied live with no restart. This is documented in the project's own README under "Privacy and Egress", and I've noted it directly in the listing description so readers see the drawback alongside the strengths.
2. **Repo age.** The repository was created in April 2026 and the first stable release was 24 April 2026, so it is a little under the 4 month bar in the guidelines. It is actively maintained (released v0.2.0 on 11 August 2026, pushed to today), MIT licensed, at ~2k stars, and maintained by the AtomicBot-ai organisation. Completely understand if you'd rather wait until it clears 4 months, or place it under Notable Mentions instead. Just say the word and I'll update the PR.

I've kept the description factual and within the 50 to 250 character range, and `make validate` passes against the schema.

---

### Supporting Material

- Source repository: https://github.com/AtomicBot-ai/atomic-agent (MIT licensed)
- Website: https://atomicagent.io
- Documentation: https://atomicagent.io/docs
- Privacy and egress documentation: https://github.com/AtomicBot-ai/atomic-agent#privacy-and-egress
- Install: `curl -fsSL https://atomicagent.io/install | sh`
- Discord: https://discord.gg/Us7qXtDGw
- X: https://x.com/atomicagent_io

No third-party security audit has been published, so I have not set `securityAudited`.

---

### Affiliation

Yes, I am affiliated. I'm the CPO of Atomic Agent and I'm submitting our own project. Flagging this clearly to avoid any conflict of interest.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
