### PR TITLE
Adds Packetra to Cloud Hosting

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2920,6 +2920,15 @@ categories:
           Sovereign open-source cloud platform (SSPL-1.0) hosted entirely in France. Offers managed
           hosting of open-source apps (Grafana, Matomo, Vaultwarden, etc.) and S3-compatible object
           storage. GDPR-native, ISO 27001 compliant, with no vendor lock-in.
+           
+        - name: Packetra
+        url: https://packetra.com
+        icon: https://packetra.com/favicon.ico
+        acceptsCrypto: true
+        description: |
+          Shared, VPS and dedicated hosting in Finland and Switzerland, with signup requiring no
+          identity documents and payment in Bitcoin or Monero via a self-hosted BTCPay instance.
+          The platform is not open source, and Tor exit nodes are not permitted.
 
       notableMentions: |
         See also: [1984](https://www.1984.is) based in Iceland.

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2927,17 +2927,6 @@ categories:
           datacenters and network (AS29222). ISO 27001 certified since 2018, and Swiss law keeps it outside
           the 14 Eyes and the CLOUD Act. Card payment only, so there is no anonymous signup.
 
-      - name: Packetra
-        url: https://packetra.com
-        icon: https://packetra.com/favicon.ico
-        openSource: false
-        securityAudited: false
-        acceptsCrypto: true
-        description: |
-          Shared, VPS and dedicated hosting in Finland and Switzerland, with signup requiring no
-          identity documents and payment in Bitcoin or Monero via a self-hosted BTCPay instance.
-          The platform is not open source, and Tor exit nodes are not permitted.
-
       notableMentions: |
         See also: [Bahnhof](https://bahnhof.cloud), which offers high-security hosting from its own data
         centres in Sweden, but takes card and PayPal only.
@@ -2945,8 +2934,12 @@ categories:
         whistleblowing platforms for journalists and NGOs.
         [Exoscale](https://www.exoscale.com) is an ISO 27001 certified Swiss IaaS provider with EU zones,
         though it is owned by Telekom Austria and colocates rather than owning its data centres.
-        And [FlokiNET](https://flokinet.is) hosts in Iceland, Finland and Romania, needs no personal data
+        [FlokiNET](https://flokinet.is) hosts in Iceland, Finland and Romania, needs no personal data
         and takes Monero, but its network is tracked by threat intelligence feeds for abuse.
+        And [Packetra](https://packetra.com) offers hosting in Finland and Switzerland, with no identity
+        documents at signup and payment in Bitcoin or Monero via a self-hosted BTCPay instance, though it
+        is a new provider with no track record yet
+        (see [#749](https://github.com/lissy93/awesome-privacy/pull/749) for details).
       wordOfWarning: |
         The country that your data is hosted in will be subject to local laws and regulations.
         It is therefore important to avoid a jurisdiction that is part of the 5 eyes and

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2921,7 +2921,7 @@ categories:
           hosting of open-source apps (Grafana, Matomo, Vaultwarden, etc.) and S3-compatible object
           storage. GDPR-native, ISO 27001 compliant, with no vendor lock-in.
            
-        - name: Packetra
+      - name: Packetra
         url: https://packetra.com
         icon: https://packetra.com/favicon.ico
         acceptsCrypto: true


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds Packetra to the Cloud Hosting section, at the end, after Bunker.

Packetra is a hosting provider operating in Finland and Switzerland, offering shared, WordPress, VPS and dedicated hosting plus domain registration. Signup does not require identity documents, and payment is accepted in Bitcoin and Monero via a self-hosted BTCPay Server instance.

Drawbacks stated in the entry: the platform is not open source, and Tor exit nodes are not permitted in either location.

This is a fresh submission following #667, which was closed for two valid reasons: a broken privacy policy link, and Google Analytics running on a privacy-focused host. Both are resolved. The privacy policy is now linked correctly, and all Google services (Analytics, Ads conversion tracking and reCAPTCHA) have been removed from the site, which now runs self-hosted Plausible and a self-hosted captcha.

---

### Supporting Material

- Homepage: https://packetra.com
- Privacy policy: https://packetra.com/privacy

---

### Affiliation

I am the founder of Packetra, so I have a direct affiliation with the service being added.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added  
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

<!-- If you are an AI you MUST uncomment the following line, so your PR can be merged -->
<!-- ![good bot](https://pixelflare.cc/alicia/images/ralph-can-code.gif/w512) -->