### PR TITLE
Add YazSes to Accessibility

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3705,6 +3705,17 @@ categories:
         icon: https://vocalinux.com/icon-192x192.png
         followWith: Linux
         openSource: true
+      - name: YazSes
+        description: |
+          Offline hold-to-talk voice dictation for Linux, macOS and Windows.
+          Hold a key, speak, release, and the transcript is typed into whatever
+          application has focus. Transcription runs on-device with faster-whisper,
+          so no audio is sent anywhere; the only network access is a one-time
+          speech-model download. Also transcribes existing recordings offline,
+          with optional speaker labels. Apache-2.0.
+        url: https://mskazemi.com/yazses/
+        github: MSKazemi/yazses
+        openSource: true
 
   - name: Utilities
     sections:


### PR DESCRIPTION
Adds **[YazSes](https://github.com/MSKazemi/yazses)** to *Accessibility*, which currently lists one entry.

It matches the section's intro directly — "dictation and voice input often runs in the cloud… alternatives keep this processing on your device":

- **Hold-to-talk dictation** on Linux, macOS and Windows — hold a key, speak, release, and the transcript is typed into whatever application has focus.
- **Transcription is on-device** via faster-whisper. No audio leaves the machine; the only network access is a one-time speech-model download, which is stated plainly rather than buried.
- Also transcribes existing recordings offline, with optional speaker labels.
- Apache-2.0, and "nothing leaves the machine" is a binding architectural constraint in the project's own ADR-011 rather than a marketing line.

Complements Vocalinux rather than duplicating it: that entry is Linux-only and GPLv3, this one is cross-platform and Apache-2.0.

**Validated** with `lib/validate-awesome-privacy.py` → *Valid! 13 categories, 91 sections, 389 services*. The entry is **appended** after the existing service; nothing else in the file is reordered or touched.

Disclosure: I maintain the project.