### PR TITLE
Add Mirror Veil (Security Tools > Online Tools)

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1976,6 +1976,18 @@ categories:
             A tool from Netcraft, for analysing what any given website is running, where it's located and information about its
             host, registrar, IP and SSL certificates.
 
+        - name: Mirror Veil
+          url: https://justlay.me/mirror-veil
+          github: justlayme/mirror-veil
+          description: |
+            Redacts names, phone numbers, email addresses and other identifiers out of a chat or message export
+            before you share it with a lawyer, a therapist or an AI. It is a single HTML file that you download and
+            open, with no upload, no account and no server, so it keeps working with the network disconnected -
+            which is an easier way to verify the claim than reading a privacy policy. Unlike pattern-based
+            redactors, it builds an alias graph so every identifier belonging to one person maps to one stable
+            token, keeping the conversation readable instead of replacing "Mike", "Mikey" and his number with three
+            unrelated blanks.
+
       wordOfWarning: >
         Browsers are inherently insecure, be careful when uploading, or entering personal details.
 

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1979,6 +1979,7 @@ categories:
         - name: Mirror Veil
           url: https://justlay.me/mirror-veil
           github: justlayme/mirror-veil
+          icon: https://justlay.me/icon-192x192.png
           description: |
             Redacts names, phone numbers, email addresses and other identifiers out of a chat or message export
             before you share it with a lawyer, a therapist or an AI. It is a single HTML file that you download and


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds **Mirror Veil** to `Security Tools > Online Tools`.

It redacts names, phone numbers, email addresses and other identifiers out of a chat or message export before that export is shared with someone else. It is distributed as a single HTML file that is downloaded and opened locally; there is no upload step, no account and no server component, and it continues to function with the network disconnected.

It differs from pattern-based redactors in how it handles identity: it builds an alias graph and maps every identifier belonging to one person to a single stable token, so "Mike", "Mikey" and that person's phone number resolve to the same placeholder rather than to three unrelated blanks. The redacted transcript therefore stays readable in sequence.

---

### Supporting Material

- Project page: https://justlay.me/mirror-veil
- Source: https://github.com/justlayme/mirror-veil
- Licence: MIT
- Single-file build: https://github.com/justlayme/mirror-veil/raw/main/dist/MirrorVeil.html

For transparency: the tool itself makes no network requests, but the project page on justlay.me does run Google Analytics. If that is disqualifying, I am happy to repoint the entry at the GitHub repository or the raw file instead.

---

### Affiliation

I am the author of Mirror Veil, and of justlay.me which hosts the project page. Declared up front.

---

### Checklist

- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [X] I have indicated whether I have any affiliation with any software / services added
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
