### PR TITLE
Adds KashCal to Calendar

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3203,6 +3203,18 @@ categories:
           Note that CalDAV support is currently limited
           (see [#921](https://github.com/FossifyOrg/Calendar/issues/921)
 
+      - name: KashCal
+        url: https://kashcal.onekash.org
+        github: KashCal/KashCal
+        androidApp: org.onekash.kashcal
+        followWith: Android
+        icon: https://raw.githubusercontent.com/KashCal/KashCal/main/images/kashcal-app.png
+        description: |
+          Offline-first Android calendar that syncs with iCloud, CalDAV and device
+          calendars. No account, no telemetry; credentials are stored in the Android
+          Keystore. Events are not end-to-end encrypted, so sync security depends on
+          your provider.
+
     ########################
     ###### Scheduling ######
     ########################


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds **KashCal** to the Productivity → Calendar section (appended at the bottom of the category). KashCal is an offline-first, open-source (Apache-2.0) Android calendar that syncs with iCloud, CalDAV servers and the device calendar. No account, no analytics, no telemetry; sync credentials are stored in the Android Keystore. Description notes the drawback that events are not end-to-end encrypted, so sync security depends on the chosen provider.

---

### Supporting Material
- Source (Apache-2.0): https://github.com/KashCal/KashCal
- Website: https://kashcal.onekash.org
- F-Droid: https://f-droid.org/packages/org.onekash.kashcal
- IzzyOnDroid: https://apt.izzysoft.de/packages/org.onekash.kashcal

First stable release January 2026 (>4 months old). YAML validated locally with `lib/validate-awesome-privacy.py` (passes schema).

---

### Affiliation
I am the developer of KashCal.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
