### PR TITLE
Adds [NOT]KYC to Crypto Exchanges

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4813,6 +4813,16 @@ categories:
           invoices to minimize custody and trust requirements.
           The deterministically generated avatars help users stick to best privacy practices.
 
+      - name: "[NOT]KYC"
+        url: https://notkyc.life
+        icon: https://notkyc.life/apple-touch-icon.png
+        acceptsCrypto: true
+        description: |
+          A directory and live-rate comparison for no-KYC crypto exchanges.
+          Compare live swap rates, privacy and trust scores and no-KYC track
+          records across 17+ anonymous services. No signup, ID or logs.
+
+
       notableMentions: |
         For traders, [BaseFEX](https://www.basefex.com/) doesn't require ID and has a good privacy policy.
 


### PR DESCRIPTION
A no-KYC exchange directory with live rate comparison and trust scores.

### Type
Addition

---

### Changes

Adds [NOT]KYC to Finance → Crypto Exchanges. It's a directory and live-rate comparison for no-KYC crypto exchanges, listing per-exchange privacy/trust scores and a community-tracked no-KYC record. Added at the bottom of the section with name, url, icon and description.

---

### Supporting Material

- Website: https://notkyc.life
- Privacy policy: https://notkyc.life/privacy
- No third-party trackers; reachable over Tor and I2P
- Closed-source (no public repo)

---

### Affiliation

Yes — I operate [NOT]KYC. Disclosing for transparency.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
