### PR TITLE
Adds Vultisig to Crypto Wallets

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4791,6 +4791,19 @@ categories:
         followWith: Bitcoin or Ethereum & ERC-20 tokens
         github: digitalbitbox/bitbox-wallet-app
 
+      - name: Vultisig
+        url: https://vultisig.com
+        icon: https://avatars.githubusercontent.com/u/157932671
+        github: vultisig/vultisig-ios
+        iosApp: https://apps.apple.com/app/apple-store/id6503023896
+        androidApp: com.vultisig.wallet
+        openSource: true
+        description: |
+          Seedless, self-custodial multi-chain wallet using MPC threshold signatures to
+          split keys across your own devices. No account or sign-up. Adds no on-chain
+          privacy: no CoinJoin, Tor routing or coin control.
+        followWith: 30+ Chains
+
       notableMentions: |
         [Metamask](https://metamask.io/) (Ethereum and ERC20 tokens) is a bridge
         that allows you to visit and interact with distributed web apps in your browser.

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4791,21 +4791,12 @@ categories:
         followWith: Bitcoin or Ethereum & ERC-20 tokens
         github: digitalbitbox/bitbox-wallet-app
 
-      - name: Vultisig
-        url: https://vultisig.com
-        icon: https://avatars.githubusercontent.com/u/157932671
-        github: vultisig/vultisig-ios
-        iosApp: https://apps.apple.com/app/apple-store/id6503023896
-        androidApp: com.vultisig.wallet
-        openSource: true
-        description: |
-          Seedless, self-custodial multi-chain wallet using MPC threshold signatures to
-          split keys across your own devices. No account or sign-up. Chain queries
-          default to Vultisig endpoints (custom RPC opt-out); no CoinJoin, Tor or coin
-          control.
-        followWith: 30+ Chains
-
       notableMentions: |
+        [Vultisig](https://vultisig.com/) is a seedless, self-custodial wallet.
+        It uses MPC threshold signatures to split your key across several devices you own,
+        so there's no seed phrase to write down or leak. It adds no on-chain privacy,
+        and chain queries default to Vultisig's own endpoints unless you set a custom RPC.
+
         [Metamask](https://metamask.io/) (Ethereum and ERC20 tokens) is a bridge
         that allows you to visit and interact with distributed web apps in your browser.
         Metamask has good hardware wallet support, so you can use it to swap, stake,

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4800,8 +4800,9 @@ categories:
         openSource: true
         description: |
           Seedless, self-custodial multi-chain wallet using MPC threshold signatures to
-          split keys across your own devices. No account or sign-up. Adds no on-chain
-          privacy: no CoinJoin, Tor routing or coin control.
+          split keys across your own devices. No account or sign-up. Chain queries
+          default to Vultisig endpoints (custom RPC opt-out); no CoinJoin, Tor or coin
+          control.
         followWith: 30+ Chains
 
       notableMentions: |


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds Vultisig to Finance > Crypto Wallets, at the end of the section.

Vultisig is a seedless, self-custodial multi-chain wallet. Instead of a seed
phrase, it uses MPC threshold signatures (DKLS23) to split a key into shares
held on separate devices you own, so no single device holds a spendable key and
there is no phrase to write down or leak. There is no account, no sign-up, and
no email or KYC step to use it.

I've kept the description factual about what it does not do: it provides no
on-chain privacy. There is no CoinJoin, no Tor routing, and no coin control.
It belongs in this section on the same basis as Trezor and BitBox02 — key
custody and no-account operation — not as a privacy-enhancing tool.

Only awesome-privacy.yml is modified. The README is untouched.

---

### Supporting Material

- Website: https://vultisig.com
- GitHub org (all clients open source, Apache-2.0): https://github.com/vultisig
- iOS client (linked in the entry): https://github.com/vultisig/vultisig-ios
- Android client: https://github.com/vultisig/vultisig-android
- Desktop client (Windows/macOS/Linux): https://github.com/vultisig/vultisig-windows
- iOS App Store: https://apps.apple.com/app/apple-store/id6503023896
- Google Play: https://play.google.com/store/apps/details?id=com.vultisig.wallet
- Trail of Bits audit of the DKLS23 threshold-signature implementation the
  wallet builds on (this is an audit of the upstream cryptographic library by
  Silence Laboratories, not of the Vultisig clients themselves):
  https://github.com/silence-laboratories/dkls23/blob/main/docs/ToB-SilenceLaboratories_2024.04.10.pdf

Two things I want to flag rather than have you find them:

1. The linked repo is under 100 stars (vultisig-ios is at 39). The clients have
   been in continuous development since January 2024, are Apache-2.0, and ship
   on the App Store and Play Store, but the star count will trip your minimum-
   stars warning. Happy for this to sit in Notable Mentions instead if you'd
   prefer.
2. I have not set securityAudited. The published Trail of Bits report covers the
   DKLS23 library, not the Vultisig applications, and I didn't think it was
   honest to claim the flag on that basis.

---

### Affiliation
Yes — I work on Vultisig. Declaring it up front. I'm happy to take edits to the
wording, move it to Notable Mentions, or withdraw if it isn't a fit for the
section.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
