### PR TITLE
Add FormatTailor to Metadata Removal

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3933,6 +3933,19 @@ categories:
         description: |
           Native MacOS app, with drag 'n drop image optimization and meta data removal.
 
+      - name: FormatTailor
+        url: https://formattailor.tech
+        icon: https://formattailor.tech/favicon.svg
+        description: |
+          Free, browser-based privacy toolkit where photos are decoded and
+          re-exported entirely client-side - nothing is ever uploaded to a
+          server. The metadata tool shows a readable report of what the file
+          carries (flagging GPS coordinates when present), then creates a fresh
+          copy containing no copied EXIF block. The same no-upload engine also
+          compresses images toward exact file-size targets, converts between
+          HEIC/PNG/WebP/JPG, resizes to precise pixel dimensions, and builds
+          website favicon/asset packs.
+
       notableMentions: |
         It's possible (but slower) to do this without a third-party tool.
         For Windows, right click on a file, and go to: `Properties --> Details --> Remove Properties --> Remove from this File --> Select All --> OK`.


### PR DESCRIPTION
Adds [FormatTailor](https://formattailor.tech) to the Metadata Removal section.

What it is: a free, no-account suite of browser-local image tools. The metadata remover inspects what a photo carries (flagging GPS coordinates when present), then exports a freshly encoded copy containing no copied EXIF block. Size-target compression, HEIC/PNG/WebP/JPG conversion, precise resizing, and website asset packs all run on the same zero-upload engine.

Fit for this list: genuinely free (ad-supported, no premium gating), requires no account, and - unlike most entries here - nothing is ever transmitted: decoding, inspection, and export happen entirely in the user's tab.

![good bot](https://pixelflare.cc/alicia/images/ralph-can-code.gif/w512)