### PR TITLE
Removes RetroShare from team collaboration

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1284,21 +1284,6 @@ categories:
           feature set is similar to Slack's, making it a good replacement for any team
           looking to have greater control over their data.
 
-      - name: RetroShare
-        url: https://retroshare.cc/
-        icon: https://retroshare.cc/img/retroshare-symbol.png
-        github: RetroShare/RetroShare
-        openSource: true
-        description: |
-          Secure group communications, with the option to be used over Tor or I2P. Fast
-          intuitive group and 1-to-1 chats with text and rich media using decentralized
-          chat rooms, with a mail feature for delivering messages to offline contacts.
-          A channels feature makes it possible for members of different teams to stay
-          up-to-date with each other, and to share files. Also includes built-in forums,
-          link aggregations, file sharing and voice and video calling. RetroShare is a
-          bit more complex to use than some alternatives, and the UI is quite *retro*,
-          so may not be appropriate for a non-technical team.
-
       - name: Element
         url: https://element.io/
         github: element-hq/element-web


### PR DESCRIPTION
### Type
Removal

---

### Changes
Removes RetroShare from team colaboration section

---

### Supporting Material

- Insecure defaults throughout
- No recent stable releases
- Dependant on the EoL botan-2
- Tor/I2P hidden-node mode effectivley broken
- Seems to still use the old openpgp-sdk
- Vendors deps, so doesn't automatically receive security patches

---

### Affiliation
None

---

### Checklist
- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

