### PR TITLE
Adds Formatho to Online Tools

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -1975,6 +1975,14 @@ categories:
             A tool from Netcraft, for analysing what any given website is running, where it's located and information about its
             host, registrar, IP and SSL certificates.
 
+        - name: Formatho
+          url: https://formatho.com
+          icon: https://formatho.com/favicon.ico
+          description: |
+            A suite of 134 free developer tools (JSON/YAML formatters, JWT decoder, hash generators,
+            Base64/URL encoders, UUID validators and more) that run entirely client-side in your
+            browser. No uploads, no accounts and no tracking - so sensitive data never leaves your device.
+
       wordOfWarning: >
         Browsers are inherently insecure, be careful when uploading, or entering personal details.
 


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds [Formatho](https://formatho.com) to the *Online Tools* section of `awesome-privacy.yml` (single entry, no other changes).

Formatho is a suite of 134 free developer tools (JSON/YAML/XML/TOML/CSV formatters and validators, JWT decoder, SAML decoder, hash generators, Base64/URL encoders, UUID/ULID validators, subnet calculator, etc.) that run entirely client-side in the browser. No uploads, no accounts, no tracking — sensitive data (tokens, keys, config files) never leaves the user's device. `make validate` passes (390 services).

**Open source:** Yes — the complete website source is MIT-licensed and public at [formatho/website](https://github.com/formatho/website), fully buildable and deployable from source by anyone.

---

### Supporting Material
- Website: https://formatho.com
- Source code (MIT): https://github.com/formatho/website
- Privacy policy: https://formatho.com/privacy
- All processing happens in-browser (works offline once loaded)

---

### Affiliation
Yes — I am associated with Formatho (submitting on behalf of the project).

---

### Checklist
- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [X] I have indicated whether I have any affiliation with any software / services added
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

![good bot](https://pixelflare.cc/alicia/images/ralph-can-code.gif/w512)