### PR TITLE
Add clearbox to Utilities > Metadata Removal

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3895,6 +3895,19 @@ categories:
         for their own use.
         This could obviously pose a security risk, and that is why it is recommended to strip out this data from a file before sharing.
       services:
+      - name: clearbox
+        url: https://wedo911.github.io/clearbox/tools/photo/
+        github: wedo911/clearbox
+        icon: https://wedo911.github.io/clearbox/favicon.svg
+        openSource: true
+        followWith: Web
+        description: |
+          Browser-based JPEG/PNG metadata viewer and remover, requiring no install. Shows exactly what a photo reveals
+          (GPS coordinates with a map link, camera make/model, timestamps, software, comments) before stripping it.
+          Parses the JPEG marker and PNG chunk structure directly rather than re-encoding, so pixel data is untouched.
+          Runs fully client-side with a service worker, so it works offline and the photo never leaves the device.
+          Part of a small bilingual (English/Arabic) suite that also covers contract, password and text checks.
+
       - name: ExifCleaner
         url: https://exifcleaner.com
         github: szTheory/exifcleaner


### PR DESCRIPTION
Adds [clearbox](https://wedo911.github.io/clearbox/tools/photo/) to **Utilities → Metadata Removal**.

**Why it adds something to that section:** ExifCleaner, ExifTool and ImageOptim are all excellent, but all three require installing a desktop application. There's currently no browser-based option listed for someone who just needs to strip the GPS coordinates out of one photo before sending it — which is the common case, and often the urgent one.

- Runs entirely client-side; the photo is never uploaded anywhere, and there is no backend at all
- Registers a service worker, so it keeps working offline after the first visit
- Shows what the photo reveals *before* stripping — GPS with a map link, camera make/model, timestamps, software, comments — so the user sees why it matters
- Parses the JPEG marker structure and PNG chunks directly and drops metadata segments, rather than re-encoding, so pixel data is bit-for-bit preserved
- MIT licensed, no tracking, no analytics, English and Arabic

I've verified the YAML parses cleanly after the edit (`js-yaml`), and placed the entry alphabetically before ExifCleaner to match the section's existing ordering.

Happy to trim the description or move it if you'd prefer it elsewhere.