### PR TITLE
Adds OneTake to Screenshot Tools

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5554,6 +5554,17 @@ categories:
     - name: Screenshot Tools
       alternativeTo: ['snagit', 'greenshot', 'lightshot', 'gyazo', 'sharex']
       services:
+      - name: OneTake
+        followWith: Chrome
+        url: https://screenrecorder.link
+        openSource: false
+        description: |
+          Records a tab, window or screen from Chrome. Encoding runs in the page:
+          gifski compiled to WebAssembly for GIF, plus WebP, AVIF and MP4. File exports
+          stay local. The optional share link uploads the recording to OneTake's server
+          during capture. No account is required either way. Free recordings stop at
+          5 minutes; 1080p and 10-minute recordings are paid.
+
       - name: ShareX
         followWith: Windows
         url: https://getsharex.com

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5554,17 +5554,6 @@ categories:
     - name: Screenshot Tools
       alternativeTo: ['snagit', 'greenshot', 'lightshot', 'gyazo', 'sharex']
       services:
-      - name: OneTake
-        followWith: Chrome
-        url: https://screenrecorder.link
-        openSource: false
-        description: |
-          Records a tab, window or screen from Chrome. Encoding runs in the page:
-          gifski compiled to WebAssembly for GIF, plus WebP, AVIF and MP4. File exports
-          stay local. The optional share link uploads the recording to OneTake's server
-          during capture. No account is required either way. Free recordings stop at
-          5 minutes; 1080p and 10-minute recordings are paid.
-
       - name: ShareX
         followWith: Windows
         url: https://getsharex.com
@@ -5578,6 +5567,14 @@ categories:
           Open-source screen-capture tool for Windows.
           Takes screenshots and short screen recordings, with annotation, OCR, a colour picker, and configurable save/upload destinations.
           Note that (if configured) it can interop with non-private services for upload, like Imgur, Google, etc.
+
+      - name: OneTake
+        followWith: Chrome
+        url: https://screenrecorder.link
+        icon: https://screenrecorder.link/icon.png
+        openSource: false
+        description: |
+          Records a tab, window or screen from Chrome and encodes it in the page, so a file export never leaves the machine. The optional share link is the one path that uploads. No account either way; free recordings stop at 5 minutes.
 
     - name: 3D Graphics
       alternativeTo: ['blender', 'autodesk maya', 'cinema 4d', '3ds max', 'sketchup']


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds OneTake to Creativity → Screenshot Tools, at the end of the section.

The section currently holds one entry, ShareX, which is Windows-only. OneTake covers
the browser side of the same job: it records a tab, window or screen from Chrome and
encodes the result in the page — gifski compiled to WebAssembly for GIF, plus WebP,
AVIF and MP4 — so a file export never leaves the machine. The optional share link is
the one path that uploads, and the entry says so rather than leaving it implied. No
account is required for either path.

It is not open source, so `openSource: false` and no `github` field. Per the
Requirements section, here are the drawbacks stated plainly: the source is closed, so
the local-encode claim is verifiable by watching the network tab rather than by
reading the code; the share feature uploads to a server the user does not control;
and it is a paid product above 5 minutes or 1080p. If that puts it in Notable
Mentions instead of the section proper, that is a reasonable call.

Two things the check bot flagged on the site have been fixed since it ran:
`screenrecorder.link` now sends HSTS, `X-Content-Type-Options`, `Referrer-Policy` and
`X-Frame-Options`, and publishes `/.well-known/security.txt`. No CSP — the page loads
Stripe checkout and a wrong policy there breaks the payment path.

---

### Supporting Material
- Site: https://screenrecorder.link
- Chrome Web Store: https://chromewebstore.google.com/detail/onetake-screen-recording/
- Privacy policy: https://screenrecorder.link/privacy
- security.txt: https://screenrecorder.link/.well-known/security.txt

---

### Affiliation
I am the developer of OneTake. I have no affiliation with ShareX or any other entry
in this category.

---

### Checklist
- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

![good bot](https://pixelflare.cc/alicia/images/ralph-can-code.gif/w512)
