### PR TITLE
Adds html.cloud to File Drop

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3544,6 +3544,19 @@ categories:
           encryption and no IP address or device info is logged. Files are permanently deleted after download or after specified
           duration. Developed by StandardNotes, and has built-in integration with the SN app.
 
+      - name: html.cloud
+        url: https://html.cloud
+        icon: https://html.cloud/apple-touch-icon.png
+        openSource: true
+        github: viljamilaurila/html-cloud
+        followWith: Web
+        description: |
+          Share a single self-contained HTML file as a private link. The file is encrypted in
+          the browser with AES-256-GCM before upload, and the decryption key stays in the URL
+          fragment, which browsers never transmit — so the server stores only ciphertext it
+          cannot read. No account required; also usable from a CLI or via an MCP server for
+          AI assistants. Self-hostable.
+
       - name: OnionShare
         url: https://onionshare.org/
         github: micahflee/onionshare


### PR DESCRIPTION
### Type
Addition

---

### Changes

Adds **html.cloud** to the **File Drop** section.

html.cloud shares a single self-contained HTML file as a private link. The file is encrypted in the browser with AES-256-GCM before anything is uploaded, and the decryption key stays in the URL fragment — which browsers never transmit — so the server stores only ciphertext it cannot read. No account required. Also usable from a CLI and via an MCP server for AI assistants. Self-hostable.

---

### Supporting Material

- Source (MIT): https://github.com/viljamilaurila/html-cloud
- How the encryption works: https://html.cloud/security
- CLI on npm: https://www.npmjs.com/package/html-cloud
- The web client, CLI and browser extension share a single crypto module, so the zero-knowledge claim is verifiable in code rather than taken on trust.

---

### Affiliation

I'm the developer of html.cloud.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
