### PR TITLE
Add swapfile.io to Utilities > Metadata Removal

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3697,6 +3697,11 @@ categories:
         icon: https://imageoptim.com/icon.png
         description: |
           Native MacOS app, with drag 'n drop image optimization and meta data removal.
+      - name: swapfile.io
+        url: https://swapfile.io
+        description: |
+          Free, browser-based tool to strip EXIF, GPS, XMP and C2PA metadata from images without uploading — the file is
+          read, cleaned and downloaded entirely on your device. Also includes an AI-metadata checker plus image, PDF and audio conversion.
 
       notableMentions: |
         It's possible (but slower) to do this without a third-party tool.


### PR DESCRIPTION
Adds **swapfile.io** to Utilities → Metadata Removal (after ImageOptim).

Why it fits this section: it strips EXIF, GPS, XMP and C2PA metadata from images **entirely in the browser** — the file is read, cleaned and downloaded on the user's own device, with **no upload to any server**. That makes it arguably more privacy-preserving than tools that require sending the file to a website. It's free, needs no sign-up, and also includes an AI-metadata checker plus image/PDF/audio conversion (all client-side).

Note: it's a free web tool, not open source, so I've left out the `github:` field. Happy to adjust the description, placement or wording to fit the list's conventions.