### PR TITLE
Adds Humla to Digital Notes

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3138,6 +3138,18 @@ categories:
           A free, open-source note-taking application built with Qt, focused on providing a pleasant Markdown
           editing experience. It manages notes directly as plain text files on your local system.
 
+      - name: Humla
+        url: https://humla.team
+        github: michaelwilhelmsen/humla
+        followWith: MacOS
+        openSource: true
+        securityAudited: false
+        icon: https://humla.team/icon.png
+        description: |
+          Meeting notes app that records your mic and the call's system audio without a bot joining.
+          Transcription, diarization and summaries run offline on Apple Silicon, or via your own
+          OpenAI/Deepgram/Groq key. Local SQLite, no telemetry. macOS only.
+
       notableMentions: |
         If you are already tied into Evernote, One Note etc, then [SafeRoom](https://www.getsaferoom.com)
         is a utility that encrypts your entire notebook, before it is uploaded to the cloud.


### PR DESCRIPTION
### Type
Addition

---

### Changes

Adds **Humla** to Productivity → Digital Notes (at the end of the section).

Humla is a free, MIT-licensed macOS app for meeting notes. You type notes during a
meeting; in parallel it captures your microphone and the call's system audio through
macOS itself, so **no bot joins the call** and the other participants aren't recorded by
a third-party service. It then transcribes, labels speakers and writes a summary that
fuses your own notes with the transcript.

Relevant to this list because the whole pipeline can run locally:

- **Transcription** — Whisper on-device via Metal on Apple Silicon, or a
  bring-your-own key for OpenAI / Deepgram / Groq if the user prefers cloud accuracy.
  The choice is per-language and explicit; nothing is sent anywhere by default.
- **Speaker identification** — offline diarization (FluidAudio, CoreML on the ANE).
  No audio leaves the machine for this step.
- **Summaries** — either a local LLM over Ollama / any OpenAI-compatible server, or the
  user's own OpenAI key.
- **Storage** — local SQLite in `~/Library/Application Support`, plus plain WAV/JSONL on
  disk. No account is required, there is no telemetry or analytics, and no backend is
  involved in the default configuration. Audio retention is off by default and there is
  an explicit "delete stored audio" sweep. Notes export to Markdown, and deleting a note
  deletes its transcript, audio and derived data.

Drawbacks, stated in the entry and here for completeness:

- **macOS only** (Apple Silicon for the on-device models); no Windows, Linux or mobile.
- No published third-party security audit, so `securityAudited: false`.
- There is an **optional** paid hosted sync service for teams (sync.humla.team) — it is
  opt-in, off by default, and the app is fully functional without ever signing in.

---

### Supporting Material

- Source: https://github.com/michaelwilhelmsen/humla (MIT, 254 stars, active — last push yesterday)
- Homepage: https://humla.team
- First stable release: [v0.1.1, 2026-04-28](https://github.com/michaelwilhelmsen/humla/releases/tag/v0.1.1) — over 4 months ago; repo created 2026-04-27
- Latest release: [v0.53.0](https://github.com/michaelwilhelmsen/humla/releases) — ~150 releases since April
- Docs / build-from-source instructions: [README](https://github.com/michaelwilhelmsen/humla#readme)
- Privacy policy: https://humla.team/privacy

---

### Affiliation

**Yes — I am the author and maintainer of Humla.** Disclosing this up front for
transparency, per the guidelines. This PR was prepared with the help of an AI assistant
working from my instructions; I've reviewed the entry and stand behind it.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

![good bot](https://pixelflare.cc/alicia/images/ralph-can-code.gif/w512)
