### PR TITLE
Add Presend to Metadata Removal

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3865,6 +3865,16 @@ categories:
           Harvey. Very good performance, and supports all common metadata formats. An official GUI application is available
           for Windows, implemented by Bogdan Hrastnik.
 
+      - name: Presend
+        url: https://presend.pages.dev
+        github: presendapp/presend
+        icon: https://presend.pages.dev/favicon.ico
+        description: |
+          Free, browser-based privacy toolkit to clean, compress and prepare files before sharing.
+          Includes EXIF remover, PDF metadata cleaner, image compressor, password generator, QR code generator,
+          file hash checker, HEIC converter and more. Nothing is ever uploaded — everything runs client-side.
+          Useful for journalists, lawyers, and privacy-conscious users who need to sanitize files before sending them.
+
       - name: ImageOptim
         url: https://imageoptim.com/mac
         followWith: MacOS


### PR DESCRIPTION
Adding Presend next to ExifCleaner and ExifTool in Metadata Removal.

The difference from those two is that Presend runs entirely in the browser — nothing to install, no CLI, files never leave the device. It also covers a few adjacent needs beyond EXIF (PDF metadata stripping, HEIC conversion, file hashing) that come up in the same 'clean this before I send it' workflow, so it felt like a natural fit alongside the existing metadata tools rather than a separate category.

Ran `make validate` locally, passes clean (13 categories, 91 sections, 389 services).