### PR TITLE
Adds SysWarden to Linux Defenses

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4311,6 +4311,18 @@ categories:
           Clears cache and deletes temporary files very effectively. This frees up disk space, improves performance, but most
           importantly helps to protect privacy.
 
+      - name: SysWarden
+        url: https://github.com/duggytuxy/syswarden
+        icon: https://avatars.githubusercontent.com/u/61513268?v=4
+        github: duggytuxy/syswarden
+        followWith: Linux
+        openSource: true
+        description: |
+          Open-source, host-local Linux security orchestrator combining nftables
+          enforcement, system telemetry, threat-intelligence feeds, out-of-band
+          WAAP log analysis and a terminal dashboard. It requires Linux
+          administration and is not an inline proxy.
+
       notableMentions: |
         [SecTools.org](https://sectools.org) is a directory or popular Unix security tools.
 


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds SysWarden to Linux Defenses. It is an open-source, host-local Linux
security orchestrator combining nftables enforcement, system telemetry,
threat-intelligence feeds, out-of-band WAAP log analysis and a terminal
dashboard. The entry states that it requires Linux administration and is not
an inline proxy.

---

### Supporting Material
- Repository and README: https://github.com/duggytuxy/syswarden
- Documentation: https://github.com/duggytuxy/syswarden/wiki
- Current qualified stable release: https://github.com/duggytuxy/syswarden/releases/tag/v4.03.3
- Public release readiness report: https://github.com/duggytuxy/syswarden/blob/main/docs/reports/PUBLIC_RELEASE_READINESS_REPORT_v4.03.3.md
- Security policy: https://github.com/duggytuxy/syswarden/blob/main/SECURITY.md
- GPLv3 license: https://github.com/duggytuxy/syswarden/blob/main/LICENSE

---

### Affiliation
I am the author and maintainer of SysWarden.

AI assistance disclosure: Codex was used to review the contribution guidelines
and help prepare the YAML entry and PR text. I reviewed and approved all
submitted content.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
