### PR TITLE
Adds BugShot to Developer Tools

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4624,6 +4624,16 @@ categories:
           with your name, email and commit metadata stripped, optionally over Tor. Anonymity
           isn't perfect, and the hosted service has had abuse-related downtime.
 
+      - name: BugShot
+        url: https://bug-shot.com
+        icon: https://bug-shot.com/favicon.ico
+        github: SinhyeokKang/bugshot-2
+        openSource: true
+        description: |
+          Chrome side panel that captures a bug as screenshots, video and console/network
+          logs, then files it to your own Jira, GitHub or Linear. Capture data goes from
+          browser to tracker with no vendor server. Chrome-only, needs broad host access.
+
   - name: Smart Home & IoT
     sections:
     - name: Voice Assistants


### PR DESCRIPTION
### Type
Addition

---

### Changes

Adds **BugShot** to the end of `Development > Developer Tools` in `awesome-privacy.yml`.

BugShot is an MIT-licensed Chrome side panel for filing bug reports. It captures a page
issue as a screenshot, a tab/screen recording or a 30-second replay, collects the console,
network and user-action logs alongside it, and submits the result to the reporter's own
Jira, GitHub, Linear, Notion, GitLab, Asana, ClickUp or Slack.

The reason it belongs on this list is the transport, not the feature set. Bug reports carry
the most sensitive slice of a production session — customer data in screenshots, tokens and
payloads in network logs, internal identifiers in console output. Hosted bug-reporting tools
receive all of it. In BugShot no capture data reaches a vendor server: the browser posts
directly to the user's own tracker, and when AI drafting is used the prompt goes directly to
the endpoint the user configured (Chrome's built-in model, or their own OpenAI-compatible or
Anthropic key). The only BugShot-operated endpoint is a stateless OAuth token-exchange proxy,
which never sees capture data. This is a structural property rather than a policy — there is
no server-side store to hold reports in the first place.

That places it on the same axis as the existing entries in this section: DevToys as an
alternative to pasting sensitive data into online tools, Bruno as a local-first alternative
to cloud API clients. The section has no equivalent for the bug-reporting step.

Drawbacks, stated in the entry and here:

- Chrome/Chromium only (Manifest V3 side panel, Chrome 116+). No Firefox or Safari build.
- Requires the `<all_urls>` host permission, so installation shows the "all sites" warning.
  It is needed to inject the picker and log recorders, capture across cross-origin
  navigation, and reach self-hosted GitLab and user-supplied LLM endpoints. Scope and
  lifecycle are documented in `docs/PERMISSION.md`.
- Analytics: anonymous, aggregate submission counts via PostHog, and no capture data is
  included. It has no opt-out toggle in the UI today.
- Small project: 13 GitHub stars and a modest install base, below this list's usual bar.

---

### Supporting Material

- Repository: https://github.com/SinhyeokKang/bugshot-2 (MIT)
- Chrome Web Store listing: https://chromewebstore.google.com/detail/ohakhekagkodklkickemonmifdcbhmig
- Privacy policy: https://bug-shot.com/en/privacy — lists every network destination and what
  is sent to each
- Security policy: https://github.com/SinhyeokKang/bugshot-2/blob/main/SECURITY.md
- Permission reference: https://github.com/SinhyeokKang/bugshot-2/blob/main/docs/PERMISSION.md
- Releases: https://github.com/SinhyeokKang/bugshot-2/releases — 115 releases since the first
  stable v1.0.2 on 2026-04-29
- Previously listed at TheJambo/awesome-testing#206 (merged 2026-08-22)

---

### Affiliation

**Disclosure: I am the author of BugShot.** I have no affiliation with any other project in
this category.

On maintainership, since the automated checks will raise it: I use Claude Code as a coding
assistant, and commits carry a `Co-Authored-By` trailer, so the AI-generated-code check will
flag this repository. Every change is reviewed, tested and released by me. Each pull request
is gated on typecheck, 371 unit-test files and a 74-spec Playwright end-to-end suite run
across four CI shards; regressions are written up in `docs/POSTMORTEM.md`, which has 135
entries. I am happy for that to be weighed, and equally happy for this PR to be closed if you
judge the project doesn't fit — I would rather you say so than spend review time on it.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
