### PR TITLE
Adds Sessionplan to Task Management

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3272,6 +3272,17 @@ categories:
           can sync via WebDAV/Dropbox/local file or self-hosted deployment.
           With a CLI, REST API and MCP for scripting, has optional BYOK AI.
 
+      - name: Sessionplan
+        url: https://sessionplan.de
+        icon: https://sessionplan.de/pwa/icon-512.png
+        github: tim-peters/sessionplan
+        openSource: true
+        description: |
+          Free, browser-based tool for building visual timeline agendas for
+          workshops, trainings and meetings. Installable PWA that works fully
+          offline; data stays in your browser. Optional real-time sync
+          requires a self-hosted backend (not E2E-encrypted).
+
     ###########################
     ###### Backup & Sync ######
     ###########################


### PR DESCRIPTION
### Type
Addition

---

### Changes
Added Sessionplan, a free, browser-based, offline-capable workshop/agenda
planning tool, to the Productivity > Task Management section.

---

### Supporting Material
- Website: https://sessionplan.de
- Source: https://github.com/tim-peters/sessionplan

---

### Affiliation
I am the developer/operator of Sessionplan. Disclosing this openly as
required by the contributing guidelines.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repository's Contributor Covenant Code of Conduct
