### PR TITLE
Add Cloudflare Security Art in Firewalls

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2587,6 +2587,16 @@ categories:
         description: |
           Enterprise firewall and router for protecting networks, built on the FreeBSD system.
 
+      - name: Cloudflare Security Art
+        url: https://github.com/buybitart/cloudflare-security-art
+        github: buybitart/cloudflare-security-art
+        openSource: true
+        icon: https://github.com/buybitart.png
+        description: |
+          Open-source Cloudflare security configurations for small websites, covering WAF rules,
+          DDoS protection, bot and AI crawler blocking, and security headers. Requires Cloudflare
+          and site-specific tuning.
+
       wordOfWarning: |
         There are different [types](https://www.networkstraining.com/different-types-of-firewalls)
         of firewalls, that are used in different circumstances.


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds [Cloudflare Security Art](https://github.com/buybitart/cloudflare-security-art) to the **Networking → Firewalls** section.

Cloudflare Security Art is an open-source collection of Cloudflare security configurations for small websites, covering WAF rules, DDoS protection, bot and AI crawler blocking, and security headers. It requires Cloudflare and may need site-specific tuning.

---

### Supporting Material

- GitHub repository: https://github.com/buybitart/cloudflare-security-art
- License: MIT
- Documentation: https://github.com/buybitart/cloudflare-security-art#readme

---

### Affiliation

I am the author/maintainer of Cloudflare Security Art and am directly affiliated with the project.

---

### Checklist

- [x] I have read the Contributing guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories Contributor Covenant Code of Conduct

---

### AI Disclosure

This pull request was prepared with assistance from AI, with the changes reviewed by the author.