### PR TITLE
Add pdf-iq to File Converters

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5375,8 +5375,19 @@ categories:
         discordInvite: kqevGxYPak
         description: |
           Web-based file conversion utility, which runs locally on your device using WebAssembly.
-          Supports 250+ formats across images, audio, documents, and video.
-
+          Supports 250+ formats across images, audio, documents, and video.          
+      - name: pdf-iq
+        url: https://pdf-iq.com
+        icon: https://pdf-iq.com/favicon.svg
+        openSource: true
+        github: billionedges-mk/pdf-iq-web
+        description: |
+          Seven PDF tools — compress, merge, split, rotate, reorder, images to PDF and OCR —
+          which run entirely inside the browser tab. The file is never uploaded: it is opened
+          by the browser, changed on the device and saved back to disk. Every page shows a
+          live count of bytes sent and third-party requests, so the claim can be checked
+          rather than taken on trust. No account, and everything except the first OCR run
+          works with the network off.          
   - name: Creativity
     sections:
     - name: Image Editors

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5375,19 +5375,17 @@ categories:
         discordInvite: kqevGxYPak
         description: |
           Web-based file conversion utility, which runs locally on your device using WebAssembly.
-          Supports 250+ formats across images, audio, documents, and video.          
+          Supports 250+ formats across images, audio, documents, and video.
+          
       - name: pdf-iq
         url: https://pdf-iq.com
         icon: https://pdf-iq.com/favicon.svg
         openSource: true
         github: billionedges-mk/pdf-iq-web
         description: |
-          Seven PDF tools — compress, merge, split, rotate, reorder, images to PDF and OCR —
-          which run entirely inside the browser tab. The file is never uploaded: it is opened
-          by the browser, changed on the device and saved back to disk. Every page shows a
-          live count of bytes sent and third-party requests, so the claim can be checked
-          rather than taken on trust. No account, and everything except the first OCR run
-          works with the network off.          
+          Seven PDF tools that run inside the browser tab: compress, merge, split, rotate,
+          reorder, images to PDF and OCR. Files are never uploaded, and every page shows a
+          live count of bytes sent.
   - name: Creativity
     sections:
     - name: Image Editors


### PR DESCRIPTION
### Type

Addition

### Changes

Adds pdf-iq to Media > File Converters.

Seven PDF tools that run client-side in the browser: compress, merge, split, rotate, reorder, images to PDF, and OCR. No upload, no account. The footer of every page shows a live count of bytes sent and third-party requests, measured with a PerformanceObserver and patched fetch/XHR/sendBeacon/WebSocket, so the claim is checkable in the page rather than asserted in a policy. The CSP is `default-src 'none'` with `connect-src 'self'`.

MIT licensed. Everything except the first OCR run works with the network off; that run fetches a language model once and works offline afterwards.

An earlier revision of this PR unintentionally modified the VERT entry. Trailing whitespace was appended to its last description line, which sits inside a block scalar and so became part of VERT's stored description. That is reverted and the diff is now purely the addition above. Thanks to the bot for catching it.

The description has also been shortened from 434 to 187 characters to fit the 50-250 range.

### Supporting Material

Site: https://pdf-iq.com
Source: https://github.com/billionedges-mk/pdf-iq-web (MIT)
Privacy policy: https://pdf-iq.com/privacy

Limitations, stated in the README rather than buried: a 60 MB file ceiling and the reason for it; only RC4 40-bit encryption tested against a real file, with AES implemented from spec but never exercised; CMYK, JPEG 2000, JBIG2 and CCITT images detected and skipped, but that path has never met a real file; OCR accuracy measured only against synthetic type; desktop Safari and Firefox untested.

### Affiliation

I am the author of pdf-iq. I built it and I maintain it.

The code is AI-assisted, written with Claude Code and reviewed and tested by me.

### Checklist

- [x] I have read the Contributing guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [X] I have indicated whether I have any affiliation with any software / services added
- [X] I agree to follow the repository's Contributor Covenant Code of Conduct