### PR TITLE
Add nosend in Image Editors

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5463,6 +5463,13 @@ categories:
         github: darktable-org/darktable
         icon: https://i.ibb.co/09PfHbG/darktable.png
         openSource: true
+          - name: nosend
+            url: https://nosend.io
+            icon: https://raw.githubusercontent.com/chivesz/nosend/main/public/logo-512.png
+            github: chivesz/nosend
+            openSource: true
+            description: |
+              Compresses and converts images (JPG, PNG, WEBP, GIF and HEIC) entirely in your browser using the Canvas API, so files never leave your device. No account, no file size limit, and metadata is stripped automatically.
 
     - name: Video Editors
       alternativeTo: ['adobe premiere pro', 'final cut pro', 'davinci resolve', 'imovie', 'sony vegas pro']

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5463,13 +5463,13 @@ categories:
         github: darktable-org/darktable
         icon: https://i.ibb.co/09PfHbG/darktable.png
         openSource: true
-          - name: nosend
-            url: https://nosend.io
-            icon: https://raw.githubusercontent.com/chivesz/nosend/main/public/logo-512.png
-            github: chivesz/nosend
-            openSource: true
-            description: |
-              Compresses and converts images (JPG, PNG, WEBP, GIF and HEIC) entirely in your browser using the Canvas API, so files never leave your device. No account, no file size limit, and metadata is stripped automatically.
+      - name: nosend
+        url: https://nosend.io
+        icon: https://raw.githubusercontent.com/chivesz/nosend/main/public/logo-512.png
+        github: chivesz/nosend
+        openSource: true
+        description: |
+          Compresses and converts images (JPG, PNG, WEBP, GIF and HEIC) entirely in your browser using the Canvas API, so files never leave your device. No account, no file size limit, and metadata is stripped automatically.
 
     - name: Video Editors
       alternativeTo: ['adobe premiere pro', 'final cut pro', 'davinci resolve', 'imovie', 'sony vegas pro']


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds nosend, a browser-based image compressor and HEIC converter, at the bottom of Creativity > Image Editors. All processing happens client-side via the Canvas API, so files are never uploaded to a server. No account, no file size limit, and metadata is stripped automatically.

---

### Supporting Material
- Website: https://nosend.io
- Source (MIT): https://github.com/chivesz/nosend

---

### Affiliation
I am the maintainer of nosend; this is my own open-source project.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

AI disclosure: this PR was prepared with the help of an AI assistant (Claude) and reviewed and submitted by me, the maintainer.