### PR TITLE
Adds Refentra to Metadata Removal

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3917,6 +3917,12 @@ categories:
         description: |
           Native MacOS app, with drag 'n drop image optimization and meta data removal.
 
+      - name: Refentra
+        url: https://refentra.com/tools/remove-image-metadata/
+        icon: https://refentra.com/icon.svg
+        description: |
+          Browser-based tools for viewing, editing, and stripping image EXIF/metadata. All processing happens locally in the browser,
+          so files are never uploaded. No account is required. Closed source; submitted by its maintainer.
       notableMentions: |
         It's possible (but slower) to do this without a third-party tool.
         For Windows, right click on a file, and go to: `Properties --> Details --> Remove Properties --> Remove from this File --> Select All --> OK`.


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds Refentra to Utilities → Metadata Removal. It provides browser-local viewing, editing, and removal of image metadata. Files are never uploaded. The service is closed source; its local-only processing is the privacy benefit and the limitation is disclosed in the entry.

---

### Supporting Material
- https://refentra.com/tools/remove-image-metadata/
- https://refentra.com/tools/edit-image-metadata/
- https://refentra.com/privacy/

---

### Affiliation
I maintain Refentra and am submitting this entry with that affiliation disclosed.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

AI assistance was used to prepare this submission.

![good bot](https://pixelflare.cc/alicia/images/ralph-can-code.gif/w512)