### PR TITLE
Adds Gadgetbridge to wearables and health section

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4694,6 +4694,21 @@ categories:
         securityAudited: false
         openSource: true
 
+    - name: Wearables & Health
+      alternativeTo: ['google fit', 'apple health', 'samsung health']
+      services:
+      - name: Gadgetbridge
+        description: |
+          Open source Android app that connects smartwatches and fitness trackers to
+          your phone without the vendor app or cloud account. Supports 30+ brands
+          (Mi Band, Amazfit, Pebble, Huawei), though feature parity and reliability
+          vary by device.
+        url: https://gadgetbridge.org/
+        icon: https://codeberg.org/Freeyourgadget/Gadgetbridge/raw/branch/master/app/src/main/res/mipmap-xxxhdpi/ic_launcher.png
+        codeberg: Freeyourgadget/Gadgetbridge
+        followWith: Android
+        openSource: true
+
   - name: Finance
     sections:
     - name: Cryptocurrencies


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds Gadgetbridge to the IoT --> Wearables section.

It's a really neat app, which let's you pair various smart gadgets without needing the vendor app. Which is awesome, since many of the manufacturer apps feel more like bloated spyware. 

Currently has support for [600+](https://gadgetbridge.org/gadgets/) devices.
Doesn't need internet or require any network permissions
There are a lot of permissions it does need, but these are all justified ([see here](https://gadgetbridge.org/basics/topics/permissions/))
No privacy policy, since no cloud service

---

### Supporting Material
- Website: https://gadgetbridge.org/
- Download: https://f-droid.org/packages/nodomain.freeyourgadget.gadgetbridge/
- Source: https://codeberg.org/Freeyourgadget/Gadgetbridge

---

### Affiliation
None

---

### Checklist
- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)