### PR TITLE
Add VaultKeepR to Password Managers

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -140,16 +140,14 @@ categories:
 
       - name: VaultKeepR
         url: https://vaultkeepr.xyz
+        icon: https://vaultkeepr.xyz/favicon.ico
         github: VaultKeepR/vaultkeepr-public
         openSource: true
         description: |
-          Zero-knowledge password manager that never asks for your email or an
-          account. Credentials and metadata are encrypted client-side
-          (Argon2id + XChaCha20-Poly1305) before leaving the device. Vaults
-          sync as encrypted blobs over IPFS and identities live as on-chain
-          smart accounts, so no server ever holds a database of who you are.
-          Browser extension plus iOS and Android apps; fully open source and
-          auditable.
+          Zero-knowledge password manager with no email and no account.
+          Credentials and metadata are encrypted client-side (Argon2id +
+          XChaCha20-Poly1305) before leaving the device. Vaults sync as
+          encrypted blobs over IPFS. Open source and auditable.
 
       notableMentions:
       - name: Password Safe

--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -137,6 +137,20 @@ categories:
           Turn a recovery key, password, or other secret into 3 cards you can keep in
           different places. Open-source, client-side only, with an offline recovery page.
 
+
+      - name: VaultKeepR
+        url: https://vaultkeepr.xyz
+        github: VaultKeepR/vaultkeepr-public
+        openSource: true
+        description: |
+          Zero-knowledge password manager that never asks for your email or an
+          account. Credentials and metadata are encrypted client-side
+          (Argon2id + XChaCha20-Poly1305) before leaving the device. Vaults
+          sync as encrypted blobs over IPFS and identities live as on-chain
+          smart accounts, so no server ever holds a database of who you are.
+          Browser extension plus iOS and Android apps; fully open source and
+          auditable.
+
       notableMentions:
       - name: Password Safe
         url: https://www.pwsafe.org


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds VaultKeepR (https://vaultkeepr.xyz) to the Password Managers category. It takes a different trust model from most entries listed here: no email and no account are required (your identity is a smart account), credentials and metadata are encrypted client-side before leaving the device, and vault sync happens as encrypted blobs over IPFS.

---

### Supporting Material
- Git repo: https://github.com/VaultKeepR/vaultkeepr-public
- Website: https://vaultkeepr.xyz

---

### Affiliation
I am the solo developer of VaultKeepR; this addition is self-submitted.

---

### Checklist
- [X] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [X] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [X] I have indicated whether I have any affiliation with any software / services added  
- [X] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)

![good bot](https://pixelflare.cc/alicia/images/ralph-can-code.gif/w512)
