### PR TITLE
Add HideMyShare to Screenshot Tools (Creativity)

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5601,6 +5601,17 @@ categories:
           Takes screenshots and short screen recordings, with annotation, OCR, a colour picker, and configurable save/upload destinations.
           Note that (if configured) it can interop with non-private services for upload, like Imgur, Google, etc.
 
+      - name: HideMyShare
+        url: https://hidemyshare.site
+        icon: https://hidemyshare.site/assets/apple-touch-icon.png
+        openSource: false
+        description: |
+          Keeps selected app windows out of screen shares, recordings and live streams on
+          Windows 10/11. Works at the OS capture level (WDA_EXCLUDEFROMCAPTURE), so hidden
+          windows disappear entirely from Zoom, Microsoft Teams, Google Meet and OBS -
+          not blurred - while staying fully visible on your own display. No virtual camera,
+          no performance hit, no account and no telemetry. Free 7-day trial, one-time purchase.
+
     - name: 3D Graphics
       alternativeTo: ['blender', 'autodesk maya', 'cinema 4d', '3ds max', 'sketchup']
       services:


### PR DESCRIPTION
## What

Adds **HideMyShare** to the **Creativity → Screenshot Tools** section of .

## About the tool

HideMyShare keeps selected app windows out of screen shares, recordings and live streams on Windows 10/11. It works at the OS capture level (): hidden windows disappear entirely from Zoom / Teams / Meet / OBS streams - not blurred - while staying visible on the user's own display. No virtual camera, no performance hit, no account, no telemetry. Free 7-day trial, one-time purchase.

- Website: https://hidemyshare.site
- Icon: https://hidemyshare.site/assets/apple-touch-icon.png
- Closed source (marked )

## Why this section

It complements screenshot tools like ShareX: instead of capturing the screen, it prevents specific windows from being captured or streamed - a privacy need that comes up constantly in remote-work setups. Similar in spirit to ScreenWings (currently listed under Mobile Apps), but for Windows desktops.

Happy to adjust the wording or move it elsewhere if a different section fits better.