### PR TITLE
[Add] rdp.monster in Cloud Hosting

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -2923,6 +2923,17 @@ categories:
           datacenters and network (AS29222). ISO 27001 certified since 2018, and Swiss law keeps it outside
           the 14 Eyes and the CLOUD Act. Card payment only, so there is no anonymous signup.
 
+      - name: rdp.monster
+        url: https://rdp.monster
+        icon: https://rdp.monster/favicon.ico
+        openSource: false
+        securityAudited: false
+        acceptsCrypto: true
+        description: |
+          Windows RDP and Linux VPS with dedicated CPU and RAM, from $8.99/month. An email is the
+          only thing needed to sign up, and payment can be in Monero, Bitcoin or 10+ other coins.
+          Hosted in Amsterdam, Paris and New York, under EU and US law.
+
       notableMentions: |
         See also: [Bahnhof](https://bahnhof.cloud), which offers high-security hosting from its own data
         centres in Sweden, but takes card and PayPal only.


### PR DESCRIPTION
## Type

Addition

## Changes

Adds rdp.monster to Networking → Cloud Hosting.

Windows RDP and Linux VPS with dedicated CPU and RAM. An email address is the only thing required to sign up, with no identity documents at any stage. Payment in Monero, Bitcoin and 10+ other cryptocurrencies, alongside card and PayPal. Servers are provisioned automatically, without manual review.

Nodes are in Amsterdam, Paris and New York. The description states the EU and US jurisdiction plainly rather than implying anything stronger.

One addition, one file, +11 lines. `make validate` passes.

## Supporting Material

- Homepage: https://rdp.monster
- Terms of Service: https://rdp.monster/terms-of-service/
- Legal notice: https://rdp.monster/legal-notice/
- Affiliate programme: https://rdp.monster/affiliates/

## Affiliation

Yes — I run rdp.monster.

## Checklist

- [x] I have read the Contributing guide and confirmed my PR aligns with requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, correct fields)
- [x] I have indicated whether I have affiliation with any software/services added
- [x] I agree to follow the repository's Contributor Covenant Code of Conduct

## Notes on the automated checks

**Open source.** This is a hosting service, not a distributable application, so there is no client to open source. The four existing entries in this same section — Njalla, Bunker, 1984 and Infomaniak — are all `openSource: false` for the same reason. Happy to be told that isn't sufficient.

**Status 403, "Wait a moment", San Francisco, AS13335.** Those readings come from Cloudflare rather than from the site: AS13335 is Cloudflare's AS and San Francisco is an edge PoP, not where the servers run. The checker was served an interstitial challenge, so the headers it measured are the challenge page's. The origin sets:

```
Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
X-Content-Type-Options: nosniff
Referrer-Policy: strict-origin-when-cross-origin
X-Frame-Options: SAMEORIGIN
Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=(), usb=()
```

I am relaxing the bot protection so your checker can reach the origin, and will comment here when it is done so the checks can be re-run.

**Genuinely missing, not disputed:** no Content-Security-Policy and no `/.well-known/security.txt`. The latter is being added now. CSP will take longer because of inline styles inherited from the previous site, so I will not claim a date.

## AI

This PR was drafted with AI assistance. All listing data was checked against the live service before submitting.
