### PR TITLE
Adds Poznote to Digital Notes

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -3139,6 +3139,20 @@ categories:
           A free, open-source note-taking application built with Qt, focused on providing a pleasant Markdown
           editing experience. It manages notes directly as plain text files on your local system.
 
+      - name: Poznote
+        url: https://poznote.com
+        github: timothepoznanski/poznote
+        followWith: Web (self-hosted, Docker)
+        openSource: true
+        securityAudited: false
+        icon: https://raw.githubusercontent.com/timothepoznanski/poznote/main/src/favicon.ico
+        discordInvite: AWhWWSEkJ
+        description: |
+          Self-hosted notes and tasks app with rich-text, Markdown and drawing editors,
+          tags, multi-user, OIDC login and a REST API. Docker-based (PHP + SQLite); the
+          only outbound call is a daily update check. No mobile apps (PWA), no end-to-end
+          encryption.
+
       notableMentions: |
         If you are already tied into Evernote, One Note etc, then [SafeRoom](https://www.getsaferoom.com)
         is a utility that encrypts your entire notebook, before it is uploaded to the cloud.


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds **Poznote** to the **Productivity > Digital Notes** section.

I built Poznote as a simple and flexible place to take notes, document procedures, keep track of things I learn, and organize knowledge, without the complexity that often comes with modern productivity tools.

Over time, it has grown into a fully-featured note-taking platform. Poznote supports rich text and Markdown, task lists, Mermaid diagrams, KaTeX math, Excalidraw drawings, workspaces, tags, full-text search, backups, an AI assistant, sharing, a REST API, and MCP integration.

The goal, however, has remained the same to keep things simple. Poznote gives you powerful tools when you need them, while staying out of the way when you don't. There’s no telemetry, no unnecessary layers of complexity, and you remain in control of your data.

**Powerful note-taking without the hassle.**

---

### Supporting Material

- Source code: https://github.com/timothepoznanski/poznote
- Website: https://poznote.com
- Discord: https://discord.gg/AWhWWSEkJ

---

### Affiliation

I am the author and maintainer of Poznote, so this is a submission of my own project.

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)
