### PR TITLE
Add Btwinus in P2P Messaging

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -825,6 +825,18 @@ categories:
           mobile - see [supported clients](https://tox.chat/clients.html). Clearly documented
           code and multiple language bindings make it easy for developers to integrate with
           Tox.
+
+      - name: Btwinus
+        url: https://btwinus.com
+        github: BTwinus/btwinus
+        icon: https://btwinus.com/android-icon-192x192.png
+        followWith: Web
+        openSource: true
+        description: |
+          Browser-only chat between two people with no account, app or server. The WebRTC
+          handshake is AES-256-GCM encrypted inside the invite link and unlocked by a passphrase
+          shared on a separate channel; messages then travel directly between the two browsers.
+
       notableMentions:
       - name: Cwtch
         url: https://cwtch.im


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds Btwinus to Communication > P2P Messaging.

Btwinus is a browser-only chat between two people with no account, no app and no server. The WebRTC offer/answer is compressed, AES-256-GCM encrypted with a PBKDF2-derived key, and carried inside the invite link's URL fragment; the passphrase is shared on a separate channel (phone, SMS, in person). Once connected, messages travel directly between the two browsers over the data channel. There is no backend, so nothing is stored server-side. Free, MIT licensed, available in English, French and Lingala.

---

### Supporting Material
- Website: https://btwinus.com
- Source: https://github.com/BTwinus/btwinus (MIT, first commit 2026-04-29, stable release v1.0.0)
- Privacy policy: https://btwinus.com/privacy/
- Security model and known limitations are documented in the README: WebRTC exposes peer IPs to each other and to the single STUN server, both users must be online at once, one-to-one only, no TURN relay, no external audit.

---

### Affiliation
I am the author and maintainer of Btwinus. This PR was drafted with AI assistance (Claude Code) from my account and reviewed before submitting.

---

### Checklist
- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)