### PR TITLE
Add SafeUnfollow in Social Networks

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -5096,6 +5096,8 @@ categories:
         - [diaspora\*](https://diasporafoundation.org), [Pleroma](https://pleroma.social), [Friendica](https://friendi.ca) and [Hubzilla ](https://hubzilla.org) - distributed, decentralized social networks, built on open protocols
         - [Tildes](https://tildes.net), [Lemmy](https://dev.lemmy.ml) and [notabug.io](https://notabug.io) - bulletin boards and news aggregators (similar to Reddit)
         - [Pixelfed](https://pixelfed.org) - A free, ethical, federated photo sharing platform (FOSS alternative to Instagram)
+        - [SafeUnfollow](https://safeunfollow.app) - shows who unfollowed you on Instagram by reading Meta's official data export in the browser, with no login and no upload (open source, MIT).
+          You have to request the export from Meta first and wait for it, and the site is ad-supported
       furtherInfo: |
         The content on many of these smaller sites tends to be more *niche*.
         To continue using Twitter, there are a couple of


### PR DESCRIPTION
### Type

Addition

---

### Changes

Adds a single line to the `notableMentions` of **Social → Social Networks**.

SafeUnfollow is not an alternative to Instagram, so it is not proposed as a `services` entry beside Mastodon or Pixelfed. It is a way to answer "who unfollowed me" from Meta's own data export instead of handing an Instagram password to a third-party app — which is the situation this section's `furtherInfo` already addresses ("if you choose to keep using them"). The ZIP is parsed in a Web Worker and stored in the browser's IndexedDB; there is no backend and no upload endpoint.

The entry states two drawbacks alongside the strengths, per the guidelines: the reader must request the export from Meta and wait for it, and the site is ad-supported. Description is 233 characters.

Only `awesome-privacy.yml` is touched — the generated README is untouched (I ran `gen_readme` locally only to confirm the two-line bullet folds into one list item, then reverted it).

Happy to move this into `furtherInfo`, or drop it entirely, if you would rather the section stayed to networks only.

---

### Supporting Material

- Site: https://safeunfollow.app
- Source (MIT): https://github.com/ignromanov/safe-unfollow
- Privacy policy: https://safeunfollow.app/docs/privacy/
- Validation:
  ```
  $ make validate
  INFO [validate-awesome-privacy.py] Valid! 13 categories, 92 sections, 391 services
  ```

**Three things your pre-review will flag, stated here so you do not have to find them:**

1. **Minimum stars** — the repo has 6. It is a consumer web app whose users arrive from search, not from GitHub, so the star count is not the usage signal. It is 11.5 months old, pushed today, MIT, not a fork, not archived.
2. **Spam detection (≥3 PRs to awesome-* repos in 2 days)** — this will fire, and it is accurate: I opened three today, to `awesome-pwa`, `awesome-local-first` and this one. Different lists, one entry each, each written for that list. Not a mass submission of the same text, but I would rather you heard it from me.
3. **AI-generated code** — see the Affiliation section.

---

### Affiliation

**I am the author of SafeUnfollow.** This is a self-submission and I have no affiliation with any other project in this category.

**AI use, declared:** I used Claude Code to research this list's structure, draft this entry and open this PR; the commit is authored by me and I have reviewed every line of it. The project itself is also developed with heavy AI assistance, so your "≥20% AI-generated code" check is likely to fire — that is true rather than a false positive.

![good bot](https://pixelflare.cc/alicia/images/ralph-can-code.gif/w512)

---

### Checklist

- [x] I have read the [Contributing](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CONTRIBUTING.md) guide, and confirmed my PR aligns with the requirements
- [x] I have performed a self-review (valid YAML formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories [Contributor Covenant Code of Conduct](https://github.com/Lissy93/awesome-privacy/blob/main/.github/CODE_OF_CONDUCT.md)