### PR TITLE
Adds EIDEX to Crypto Exchanges

### DIFF
--- a/awesome-privacy.yml
+++ b/awesome-privacy.yml
@@ -4882,6 +4882,10 @@ categories:
         is tagged with its KYC level, jurisdiction, supported payment methods, and a trust score
         reflecting audit history and known incidents.
 
+        [EIDEX](https://eidex.io) is a non-custodial route screener: it pulls live quotes from several
+        swap providers and ranks them by the amount you receive. No account is needed to compare, but it
+        is closed source, and the provider you pick applies its own KYC policy.
+
     - name: Virtual Credit Cards
       alternativeTo: ['visa', 'mastercard', 'american express', 'discover', 'capital one']
       intro: |


### PR DESCRIPTION
### Type
Addition

---

### Changes
Adds EIDEX to the Notable Mentions of the Crypto Exchanges section.

It is a route screener rather than an exchange: it pulls live quotes from several swap providers and ranks them by the payout, so the comparison happens before you commit to one of them. It holds no funds and does not execute the swap - that happens on the provider's own site.

Placed in Notable Mentions rather than the main list because the source is closed, which does not meet the open source requirement. The entry says so explicitly, along with the fact that the chosen provider's kyc policy still applies.

---

### Supporting Material
- Site: https://eidex.io
- The screener itself: https://eidex.io/screener
- Privacy policy: https://eidex.io/legal/privacy
- Terms: https://eidex.io/legal/terms

---

### Affiliation
I work on Eidex, disclosing this as the contributing guide requires.

---

### Checklist
- [x] I have read the contributing guide, and confirmed my pr aligns with the requirements
- [x] I have performed a self-review (valid yaml formatting, spelling, all correct fields)
- [x] I have indicated whether I have any affiliation with any software / services added
- [x] I agree to follow the repositories Contributor Covenant code of conduct